### PR TITLE
Try to optimize the user experience of the sticky notes window.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,33 @@
+root = true
+
+[*.cs]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+dotnet_diagnostic.IDE0005.severity = warning
+dotnet_diagnostic.IDE0055.severity = warning
+dotnet_diagnostic.IDE0160.severity = warning
+dotnet_diagnostic.IDE0161.severity = warning
+dotnet_diagnostic.CA1031.severity = warning
+dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.CA1307.severity = warning
+dotnet_diagnostic.CA1308.severity = warning
+dotnet_diagnostic.CA1309.severity = warning
+dotnet_diagnostic.CA1416.severity = warning
+dotnet_diagnostic.CA2000.severity = warning
+dotnet_diagnostic.CA2007.severity = warning
+dotnet_diagnostic.CA2208.severity = warning
+dotnet_diagnostic.CA5400.severity = warning
+dotnet_diagnostic.IDE0008.severity = suggestion
+
+csharp_new_line_before_open_brace = all
+csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = false:suggestion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Repository Guidelines
+
+# Rules of Implementations
+
+YOU SHOULD NOT CHANGE THIS SECTION DURING UPDATE AGENTS.md
+
+1. Avoid degradation handling, fallback, hacks, heuristics, local stabilization, or post-processing bandages that are not faithful general algorithms.
+2. Always write module docs and function docs.
+3. Keep the file short, if the file is too long, separates code to other file under the same dir.
+
+## Project Structure & Module Organization
+`YASN.csproj` is a single Windows desktop app targeting `.NET 10` with WPF, WinForms interop, WebView2, and Markdig. Most app entry points live at the repository root: `App.xaml`, `MainWindow.xaml`, `FloatingWindow.xaml`, and their `.cs` code-behind files. Keep feature-specific logic in the existing folders: `Settings/` for persisted options and settings UI helpers, `Sync/` for sync abstractions and WebDAV support, `Markdown/` for preview extensions, `Logging/` for diagnostics, `Resources/` for icons and `.resx` assets, and `style/` for packaged CSS. Ignore build output under `bin/`, `obj/`, and local NuGet cache content under `.nuget/`.
+
+## Build, Test, and Development Commands
+Use the same commands as CI on Windows:
+
+- `dotnet restore YASN.sln` restores packages.
+- `dotnet build YASN.sln -c Release --no-restore` builds the app in the CI configuration.
+- `dotnet run --project YASN.csproj` launches the app locally for interactive testing.
+- `dotnet publish YASN.csproj -c Release -r win-x64 --self-contained false -o publish` creates the release artifact used by `.github/workflows/release.yml`.
+- `dotnet format YASN.sln` applies `.editorconfig` formatting and analyzer fixes before review.
+
+## Coding Style & Naming Conventions
+Follow `.editorconfig`: UTF-8, CRLF, 4-space indentation, trailing whitespace trimmed, and braces on new lines. Prefer explicit C# types over `var` unless the type is obvious and already established nearby. Use PascalCase for public types, methods, XAML controls, and properties; use camelCase for locals and private fields. Match the current partial-class pairing pattern: `WindowName.xaml` with `WindowName.xaml.cs`.
+
+## Testing Guidelines
+There is no dedicated test project yet, and CI currently validates restore and release builds only. For changes, add focused manual checks: app startup, note editing, markdown preview rendering, settings persistence, and WebDAV sync when touching `Sync/`. If you introduce automated tests later, place them in a separate `*.Tests` project and keep test names descriptive, for example `SyncManagerTests`.
+
+## Commit & Pull Request Guidelines
+Recent history favors short, imperative subjects such as `fix on settings loading` or `add linter`, sometimes with issue references like `(#7)`. Keep commit titles concise, scoped to one change, and include an issue number when applicable. PRs should summarize user-visible behavior, note config or migration impact, and include screenshots or short recordings for XAML or styling changes.

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,9 +1,9 @@
-﻿using System.IO;
-using MessageBox = ModernWpf.MessageBox;
+using System.IO;
 using System.Windows;
 using System.Windows.Threading;
 using YASN.Logging;
 using YASN.Sync;
+using MessageBox = ModernWpf.MessageBox;
 
 namespace YASN
 {
@@ -39,38 +39,48 @@ namespace YASN
 
             // Create tray icon
             _notifyIcon = new NotifyIcon();
-            
+
             // Load icon from the same icon file used by the EXE
             try
             {
-                var iconPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "amy.ico");
+                string iconPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Resources", "amy.ico");
                 _notifyIcon.Icon = File.Exists(iconPath) ? new Icon(iconPath) :
                     // Fallback to embedded resource
                     YASN.Properties.Resources.bitbug_favicon;
             }
-            catch
+            catch (IOException ex)
             {
-                // Fallback to embedded resource
+                AppLogger.Warn($"Failed to load tray icon from disk: {ex.Message}");
                 _notifyIcon.Icon = YASN.Properties.Resources.bitbug_favicon;
             }
-            
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Warn($"Failed to load tray icon from disk: {ex.Message}");
+                _notifyIcon.Icon = YASN.Properties.Resources.bitbug_favicon;
+            }
+            catch (ArgumentException ex)
+            {
+                AppLogger.Warn($"Failed to load tray icon from disk: {ex.Message}");
+                _notifyIcon.Icon = YASN.Properties.Resources.bitbug_favicon;
+            }
+
             _notifyIcon.Visible = true;
             _notifyIcon.Text = YASN.Properties.Resources.MainTitle;
 
             // Create context menu
-            var contextMenu = new ContextMenuStrip();
-            
-            var newWindowMenuItem = new ToolStripMenuItem("NewNote(&N)");
+            ContextMenuStrip contextMenu = new ContextMenuStrip();
+
+            ToolStripMenuItem newWindowMenuItem = new ToolStripMenuItem("NewNote(&N)");
             newWindowMenuItem.DropDownItems.Add("Normal(&P)", null, CreateNormalWindowMenuItem_Click);
             newWindowMenuItem.DropDownItems.Add("TopMost(&T)", null, CreateTopWindowMenuItem_Click);
             newWindowMenuItem.DropDownItems.Add("BottomMost(&B)", null, CreateBottomWindowMenuItem_Click);
-            
-            var separatorMenuItem = new ToolStripSeparator();
-            
-            var showMainMenuItem = new ToolStripMenuItem("Main(&S)");
+
+            ToolStripSeparator separatorMenuItem = new ToolStripSeparator();
+
+            ToolStripMenuItem showMainMenuItem = new ToolStripMenuItem("Main(&S)");
             showMainMenuItem.Click += (s, args) => ShowMainWindow();
-            
-            var exitMenuItem = new ToolStripMenuItem("Exit(&X)");
+
+            ToolStripMenuItem exitMenuItem = new ToolStripMenuItem("Exit(&X)");
             exitMenuItem.Click += (s, args) => ExitApplication();
 
             contextMenu.Items.Add(newWindowMenuItem);
@@ -82,7 +92,7 @@ namespace YASN
 
             // Double-click to show main window
             _notifyIcon.DoubleClick += (s, args) => ShowMainWindow();
-            
+
             // Restore previously opened notes after a short delay to ensure everything is initialized
             Dispatcher.BeginInvoke(new Action(() =>
             {
@@ -95,10 +105,10 @@ namespace YASN
         {
             // Ensure flag is set even if ExitApplication wasn't called
             FloatingWindow.SetApplicationShuttingDown();
-            
+
             // Dispose sync manager
             SyncManager?.Dispose();
-            
+
             _notifyIcon?.Dispose();
             base.OnExit(e);
             try
@@ -107,9 +117,13 @@ namespace YASN
                 _singleInstanceMutex?.Dispose();
                 _singleInstanceMutex = null;
             }
-            catch
+            catch (ApplicationException ex)
             {
-                // ignored
+                AppLogger.Debug($"Failed to release single-instance mutex: {ex.Message}");
+            }
+            catch (ObjectDisposedException ex)
+            {
+                AppLogger.Debug($"Failed to release single-instance mutex: {ex.Message}");
             }
         }
 
@@ -121,27 +135,38 @@ namespace YASN
                 _singleInstanceMutex = new System.Threading.Mutex(true, MutexName, out createdNew);
                 return createdNew;
             }
-            catch
+            catch (UnauthorizedAccessException ex)
             {
+                AppLogger.Warn($"Failed to create single-instance mutex: {ex.Message}");
+                return true; // fail open to avoid blocking launch if mutex creation fails
+            }
+            catch (IOException ex)
+            {
+                AppLogger.Warn($"Failed to create single-instance mutex: {ex.Message}");
+                return true; // fail open to avoid blocking launch if mutex creation fails
+            }
+            catch (WaitHandleCannotBeOpenedException ex)
+            {
+                AppLogger.Warn($"Failed to create single-instance mutex: {ex.Message}");
                 return true; // fail open to avoid blocking launch if mutex creation fails
             }
         }
 
         private void CreateTopWindowMenuItem_Click(object sender, System.EventArgs e)
         {
-            var noteData = NoteManager.Instance.CreateNote(WindowLevel.TopMost);
+            NoteData noteData = NoteManager.Instance.CreateNote(WindowLevel.TopMost);
             OpenNote(noteData);
         }
 
         private void CreateNormalWindowMenuItem_Click(object sender, System.EventArgs e)
         {
-            var noteData = NoteManager.Instance.CreateNote(WindowLevel.Normal);
+            NoteData noteData = NoteManager.Instance.CreateNote(WindowLevel.Normal);
             OpenNote(noteData);
         }
 
         private void CreateBottomWindowMenuItem_Click(object sender, System.EventArgs e)
         {
-            var noteData = NoteManager.Instance.CreateNote(WindowLevel.BottomMost);
+            NoteData noteData = NoteManager.Instance.CreateNote(WindowLevel.BottomMost);
             OpenNote(noteData);
         }
 
@@ -149,7 +174,7 @@ namespace YASN
         {
             if (!noteData.IsOpen || noteData.Window == null)
             {
-                var window = new FloatingWindow(noteData);
+                FloatingWindow window = new (noteData);
                 window.Show();
             }
             else
@@ -161,7 +186,7 @@ namespace YASN
         private void ShowMainWindow()
         {
             MainWindow.Show();
-            MainWindow.WindowState = System.Windows.WindowState.Normal;
+            MainWindow.WindowState = WindowState.Normal;
             MainWindow.Activate();
         }
 
@@ -169,7 +194,7 @@ namespace YASN
         {
             // Notify all floating windows that application is shutting down
             FloatingWindow.SetApplicationShuttingDown();
-            
+
             _notifyIcon?.Dispose();
             Current.Shutdown();
         }

--- a/AppPaths.cs
+++ b/AppPaths.cs
@@ -43,7 +43,7 @@ namespace YASN
             errorMessage = string.Empty;
             try
             {
-                var raw = string.IsNullOrWhiteSpace(value)
+                string raw = string.IsNullOrWhiteSpace(value)
                     ? Path.Combine(BaseDirectory, "data")
                     : value.Trim();
 
@@ -54,10 +54,32 @@ namespace YASN
                 Directory.CreateDirectory(normalizedPath);
                 return true;
             }
-            catch (Exception ex)
+            catch (ArgumentException ex)
             {
                 normalizedPath = string.Empty;
                 errorMessage = ex.Message;
+                System.Diagnostics.Debug.WriteLine($"Failed to normalize data directory: {ex.Message}");
+                return false;
+            }
+            catch (IOException ex)
+            {
+                normalizedPath = string.Empty;
+                errorMessage = ex.Message;
+                System.Diagnostics.Debug.WriteLine($"Failed to normalize data directory: {ex.Message}");
+                return false;
+            }
+            catch (NotSupportedException ex)
+            {
+                normalizedPath = string.Empty;
+                errorMessage = ex.Message;
+                System.Diagnostics.Debug.WriteLine($"Failed to normalize data directory: {ex.Message}");
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                normalizedPath = string.Empty;
+                errorMessage = ex.Message;
+                System.Diagnostics.Debug.WriteLine($"Failed to normalize data directory: {ex.Message}");
                 return false;
             }
         }
@@ -68,21 +90,29 @@ namespace YASN
             {
                 try
                 {
-                    var json = File.ReadAllText(LocalSettingsPath);
+                    string json = File.ReadAllText(LocalSettingsPath);
                     var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-                    if (dict != null && dict.TryGetValue(DataDirectorySettingKey, out var value) &&
-                        TryNormalizeDataDirectory(value, out var configuredPath, out _))
+                    if (dict != null && dict.TryGetValue(DataDirectorySettingKey, out string? value) &&
+                        TryNormalizeDataDirectory(value, out string? configuredPath, out _))
                     {
                         return configuredPath;
                     }
                 }
-                catch
+                catch (IOException ex)
                 {
-                    // ignore malformed local settings and fallback to default path
+                    System.Diagnostics.Debug.WriteLine($"Failed to read local settings for data directory: {ex.Message}");
+                }
+                catch (JsonException ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Failed to read local settings for data directory: {ex.Message}");
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Failed to read local settings for data directory: {ex.Message}");
                 }
             }
 
-            TryNormalizeDataDirectory(null, out var defaultPath, out _);
+            TryNormalizeDataDirectory(null, out string? defaultPath, out _);
             return defaultPath;
         }
 
@@ -93,21 +123,21 @@ namespace YASN
 
         public static string GetNoteAssetsDirectory(int noteId)
         {
-            var path = Path.Combine(NoteAssetsRoot, noteId.ToString());
+            string path = Path.Combine(NoteAssetsRoot, noteId.ToString(System.Globalization.CultureInfo.InvariantCulture));
             Directory.CreateDirectory(path);
             return path;
         }
 
         public static string GetNoteBackgroundDirectory(int noteId)
         {
-            var path = Path.Combine(NoteBackgroundsRoot, noteId.ToString());
+            string path = Path.Combine(NoteBackgroundsRoot, noteId.ToString(System.Globalization.CultureInfo.InvariantCulture));
             Directory.CreateDirectory(path);
             return path;
         }
 
         public static string GetNoteAttachmentsDirectory(int noteId)
         {
-            var path = Path.Combine(NoteAttachmentsRoot, noteId.ToString());
+            string path = Path.Combine(NoteAttachmentsRoot, noteId.ToString(System.Globalization.CultureInfo.InvariantCulture));
             Directory.CreateDirectory(path);
             return path;
         }

--- a/AutoStartManager.cs
+++ b/AutoStartManager.cs
@@ -1,12 +1,10 @@
-using System;
 using System.IO;
+using System.Security;
 using Microsoft.Win32;
+using YASN.Logging;
 
 namespace YASN
 {
-    /// <summary>
-    /// ����Ӧ�ó��򿪻�����������
-    /// </summary>
     public static class AutoStartManager
     {
         private const string AppName = "YASN";
@@ -17,90 +15,112 @@ namespace YASN
         {
             try
             {
-                using var key = Registry.CurrentUser.OpenSubKey(RegistryKey, false);
+                using RegistryKey? key = Registry.CurrentUser.OpenSubKey(RegistryKey, false);
                 if (key == null)
                     return false;
 
-                var value = key.GetValue(AppName) as string;
+                string? value = key.GetValue(AppName) as string;
                 if (string.IsNullOrEmpty(value))
                     return false;
 
-                var currentPath = GetApplicationPath();
+                string currentPath = GetApplicationPath();
                 return value.Equals(currentPath, StringComparison.OrdinalIgnoreCase);
             }
-            catch
+            catch (IOException ex)
             {
+                AppLogger.Warn($"Failed to read auto-start setting: {ex.Message}");
+                return false;
+            }
+            catch (SecurityException ex)
+            {
+                AppLogger.Warn($"Failed to read auto-start setting: {ex.Message}");
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Warn($"Failed to read auto-start setting: {ex.Message}");
                 return false;
             }
         }
-        
+
         public static bool EnableAutoStart()
         {
             try
             {
-                using (var key = Registry.CurrentUser.OpenSubKey(RegistryKey, true))
-                {
-                    if (key == null)
-                        return false;
+                using RegistryKey? key = Registry.CurrentUser.OpenSubKey(RegistryKey, true);
+                if (key == null)
+                    return false;
 
-                    var applicationPath = GetApplicationPath();
-                    key.SetValue(AppName, applicationPath);
-                    return true;
-                }
+                string applicationPath = GetApplicationPath();
+                key.SetValue(AppName, applicationPath);
+                return true;
             }
-            catch (Exception)
+            catch (IOException ex)
             {
+                AppLogger.Warn($"Failed to enable auto-start: {ex.Message}");
+                return false;
+            }
+            catch (SecurityException ex)
+            {
+                AppLogger.Warn($"Failed to enable auto-start: {ex.Message}");
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Warn($"Failed to enable auto-start: {ex.Message}");
                 return false;
             }
         }
-        
+
         public static bool DisableAutoStart()
         {
             try
             {
-                using (var key = Registry.CurrentUser.OpenSubKey(RegistryKey, true))
+                using RegistryKey? key = Registry.CurrentUser.OpenSubKey(RegistryKey, true);
+                if (key == null)
+                    return false;
+
+                if (key.GetValue(AppName) != null)
                 {
-                    if (key == null)
-                        return false;
-                    
-                    if (key.GetValue(AppName) != null)
-                    {
-                        key.DeleteValue(AppName, false);
-                    }
-                    return true;
+                    key.DeleteValue(AppName, false);
                 }
+                return true;
             }
-            catch (Exception)
+            catch (IOException ex)
             {
+                AppLogger.Warn($"Failed to disable auto-start: {ex.Message}");
+                return false;
+            }
+            catch (SecurityException ex)
+            {
+                AppLogger.Warn($"Failed to disable auto-start: {ex.Message}");
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Warn($"Failed to disable auto-start: {ex.Message}");
                 return false;
             }
         }
-        
+
         public static bool ToggleAutoStart()
         {
-            if (IsAutoStartEnabled())
-            {
-                return DisableAutoStart();
-            }
-            else
-            {
-                return EnableAutoStart();
-            }
+            return IsAutoStartEnabled() ? DisableAutoStart() : EnableAutoStart();
         }
-        
+
         private static string GetApplicationPath()
         {
-            var exePath = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
+            string? exePath = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
             if (string.IsNullOrEmpty(exePath))
             {
                 exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
             }
-            
+
             if (exePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
             {
                 exePath = Path.ChangeExtension(exePath, ".exe");
             }
-            
+
             return $"\"{exePath}\"";
         }
     }

--- a/FloatingWindow.xaml
+++ b/FloatingWindow.xaml
@@ -226,29 +226,36 @@
                         Grid.Row="0"
                         Height="40"
                         Background="#E6D4C5E0"
-                        CornerRadius="5,5,0,0">
+                        CornerRadius="5,5,0,0"
+                        PreviewMouseRightButtonUp="TitleBar_MouseRightButtonUp"
+                        MouseRightButtonUp="TitleBar_MouseRightButtonUp">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
 
-                        <Button Grid.Column="0" Content="&#xE712;" ToolTip="More" Style="{StaticResource IconTitleBarButtonStyle}" Click="MoreOptions_Click"/>
-                        <Border Grid.Column="1" Background="Transparent" MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                        <Border Grid.Column="0"
+                                Background="Transparent"
+                                MouseLeftButtonDown="TitleBar_MouseLeftButtonDown"
+                                PreviewMouseRightButtonUp="TitleBar_MouseRightButtonUp"
+                                MouseRightButtonUp="TitleBar_MouseRightButtonUp">
                             <TextBlock x:Name="StatusText"
                                        Text="Note #1"
+                                       PreviewMouseRightButtonUp="TitleBar_MouseRightButtonUp"
+                                       MouseRightButtonUp="TitleBar_MouseRightButtonUp"
                                        VerticalAlignment="Center"
                                        HorizontalAlignment="Center"
                                        Foreground="#2C3E50"
                                        FontSize="13"
                                        FontWeight="SemiBold"/>
                         </Border>
-                        <StackPanel Grid.Column="2" Orientation="Horizontal">
+                        <StackPanel Grid.Column="1" Orientation="Horizontal">
                             <Button x:Name="EditorModeButton" Content="&#xE70F;" ToolTip="Switch Editor Mode" Style="{StaticResource IconTitleBarButtonStyle}" Click="EditorModeButton_Click"/>
                             <Button x:Name="ThemeToggleButton" Content="&#xE706;" ToolTip="Switch Theme" Style="{StaticResource IconTitleBarButtonStyle}" Click="ThemeToggle_Click"/>
                             <Button x:Name="PinTopButton" Content="&#xE718;" ToolTip="Pin Top" Style="{StaticResource IconTitleBarButtonStyle}" Click="PinButton_Click"/>
                             <Button x:Name="PinBottomButton" Content="&#xE74B;" ToolTip="To Bottom" Style="{StaticResource IconTitleBarButtonStyle}" Click="SendToBottom_Click"/>
+                            <Button x:Name="QuickResizeButton" Content="&#xE8A7;" ToolTip="Quick Resize" Style="{StaticResource IconTitleBarButtonStyle}" Click="QuickResizeButton_Click"/>
                             <Button x:Name="MinimizeButton" Content="&#xE921;" ToolTip="Minimize" Style="{StaticResource IconTitleBarButtonStyle}" Click="MinimizeButton_Click"/>
                             <Button Content="&#xE8BB;" ToolTip="Close" Style="{StaticResource CloseButtonStyle}" Click="CloseButton_Click"/>
                         </StackPanel>

--- a/FloatingWindow.xaml.cs
+++ b/FloatingWindow.xaml.cs
@@ -1,7 +1,9 @@
-﻿using System.IO;
-using System.Runtime.InteropServices;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Windows;
 using System.Windows.Controls;
@@ -22,11 +24,12 @@ using Color = System.Windows.Media.Color;
 using ColorConverter = System.Windows.Media.ColorConverter;
 using ContextMenu = System.Windows.Controls.ContextMenu;
 using DataFormats = System.Windows.DataFormats;
-using DrawingColor = System.Drawing.Color;
+using DragDeltaEventArgs = System.Windows.Controls.Primitives.DragDeltaEventArgs;
 using DragDropEffects = System.Windows.DragDropEffects;
 using DragEventArgs = System.Windows.DragEventArgs;
-using DragDeltaEventArgs = System.Windows.Controls.Primitives.DragDeltaEventArgs;
+using DrawingColor = System.Drawing.Color;
 using HorizontalAlignment = System.Windows.HorizontalAlignment;
+using Image = System.Drawing.Image;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using MenuItem = System.Windows.Controls.MenuItem;
 using MessageBox = ModernWpf.MessageBox;
@@ -77,7 +80,7 @@ namespace YASN
                                                          })();
                                                          """;
 
-        
+
         [LibraryImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int x, int y, int cx, int cy, uint uFlags);
@@ -121,7 +124,7 @@ namespace YASN
         private double _pendingPreviewScrollRatio = -1;
 
         private static FloatingWindow _currentBottomMostWindow;
-        private static readonly Lock _bottomMostLock = new ();
+        private static readonly Lock _bottomMostLock = new();
         private static bool _isApplicationShuttingDown;
 
         public NoteData NoteData { get; private set; }
@@ -184,7 +187,7 @@ namespace YASN
             _previewDebounceTimer.Tick += async (_, _) =>
             {
                 _previewDebounceTimer.Stop();
-                await RenderPreviewAsync();
+                await RenderPreviewAsync().ConfigureAwait(false);
             };
 
             RefreshChromeBehaviorFromSettings();
@@ -209,7 +212,7 @@ namespace YASN
                 return;
             }
 
-            var hasContent = !string.IsNullOrWhiteSpace(GetContent());
+            bool hasContent = !string.IsNullOrWhiteSpace(GetContent());
             if (!hasContent)
             {
                 SetDisplayMode(GetConfiguredEditorEnterMode(), adjustWindowWidth: false);
@@ -232,13 +235,13 @@ namespace YASN
 
         private void EnterConfiguredEditMode(bool focusEditor = false)
         {
-            var targetMode = GetConfiguredEditorEnterMode();
+            EditorDisplayMode targetMode = GetConfiguredEditorEnterMode();
             SetDisplayMode(targetMode, focusEditor: focusEditor && targetMode != EditorDisplayMode.PreviewOnly);
         }
 
         private EditorDisplayMode GetConfiguredEditorEnterMode()
         {
-            var settingsStore = new SettingsStore();
+            SettingsStore settingsStore = new SettingsStore();
             return EditorDisplayModeSettings.GetEnterMode(settingsStore);
         }
 
@@ -247,17 +250,17 @@ namespace YASN
             bool focusEditor = false,
             bool adjustWindowWidth = true)
         {
-            var previousMode = _editorDisplayMode;
+            EditorDisplayMode previousMode = _editorDisplayMode;
             _editorDisplayMode = mode;
-            var shouldPersistDisplayMode = NoteData.LastEditorDisplayMode != mode;
+            bool shouldPersistDisplayMode = NoteData.LastEditorDisplayMode != mode;
             if (shouldPersistDisplayMode)
             {
                 NoteData.LastEditorDisplayMode = mode;
             }
 
-            var showEditor = mode is EditorDisplayMode.TextOnly or EditorDisplayMode.TextAndPreview;
-            var showPreview = mode is EditorDisplayMode.PreviewOnly or EditorDisplayMode.TextAndPreview;
-            var showSplitter = mode == EditorDisplayMode.TextAndPreview;
+            bool showEditor = mode is EditorDisplayMode.TextOnly or EditorDisplayMode.TextAndPreview;
+            bool showPreview = mode is EditorDisplayMode.PreviewOnly or EditorDisplayMode.TextAndPreview;
+            bool showSplitter = mode == EditorDisplayMode.TextAndPreview;
 
             NoteData.IsEditMode = showEditor;
             MarkdownToolbar.Visibility = showEditor ? Visibility.Visible : Visibility.Collapsed;
@@ -277,17 +280,18 @@ namespace YASN
             UpdatePreviewContainerAppearance(mode);
             UpdateEditorModeButton();
 
-            if (adjustWindowWidth &&
-                mode == EditorDisplayMode.TextAndPreview &&
-                previousMode != EditorDisplayMode.TextAndPreview)
+            switch (adjustWindowWidth)
             {
-                ExpandWindowWidthForSplitMode();
-            }
-            else if (adjustWindowWidth &&
-                     previousMode == EditorDisplayMode.TextAndPreview &&
-                     mode != EditorDisplayMode.TextAndPreview)
-            {
-                RestoreWindowWidthAfterSplitMode();
+                case true when
+                    mode == EditorDisplayMode.TextAndPreview &&
+                    previousMode != EditorDisplayMode.TextAndPreview:
+                    ExpandWindowWidthForSplitMode();
+                    break;
+                case true when
+                    previousMode == EditorDisplayMode.TextAndPreview &&
+                    mode != EditorDisplayMode.TextAndPreview:
+                    RestoreWindowWidthAfterSplitMode();
+                    break;
             }
 
             if (showEditor)
@@ -319,14 +323,14 @@ namespace YASN
                 return;
             }
 
-            var keepExpandedForEditor = NoteData.IsEditMode &&
+            bool keepExpandedForEditor = NoteData.IsEditMode &&
                                         (ContentTextBox.IsKeyboardFocusWithin || ContentTextBox.IsMouseOver);
             SetChromeExpanded(keepExpandedForEditor || IsMouseInsideWindow());
         }
 
         public void RefreshChromeBehaviorFromSettings()
         {
-            var settingsStore = new SettingsStore();
+            SettingsStore settingsStore = new SettingsStore();
             _autoCollapseChromeEnabled = NoteWindowUiSettings.IsAutoCollapseChromeEnabled(settingsStore);
             AppLogger.Debug($"Load chrome behavior settings: {_autoCollapseChromeEnabled}");
             UpdateChromeBarsByMouseState();
@@ -336,8 +340,8 @@ namespace YASN
         {
             const double fallbackMinWidth = 320;
             const double fallbackMinHeight = 220;
-            var minWidth = MinWidth > 0 ? MinWidth : fallbackMinWidth;
-            var minHeight = MinHeight > 0 ? MinHeight : fallbackMinHeight;
+            double minWidth = MinWidth > 0 ? MinWidth : fallbackMinWidth;
+            double minHeight = MinHeight > 0 ? MinHeight : fallbackMinHeight;
 
             Width = Math.Max(minWidth, Width + e.HorizontalChange);
             Height = Math.Max(minHeight, Height + e.VerticalChange);
@@ -380,7 +384,7 @@ namespace YASN
                 return;
             }
 
-            var radius = Math.Max(0, PreviewContainer.CornerRadius.TopLeft);
+            double radius = Math.Max(0, PreviewContainer.CornerRadius.TopLeft);
             PreviewWebView.Clip = new RectangleGeometry(
                 new Rect(0, 0, PreviewWebView.ActualWidth, PreviewWebView.ActualHeight),
                 radius,
@@ -409,7 +413,7 @@ namespace YASN
                 return false;
             }
 
-            var dipPoint = PointFromScreen(new Point(nativePoint.X, nativePoint.Y));
+            Point dipPoint = PointFromScreen(new Point(nativePoint.X, nativePoint.Y));
             return dipPoint is { X: >= 0, Y: >= 0 } &&
                    dipPoint.X <= ActualWidth &&
                    dipPoint.Y <= ActualHeight;
@@ -450,7 +454,7 @@ namespace YASN
 
         private void ContentTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
         {
-            var isPasteShortcut = (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control && e.Key == Key.V;
+            bool isPasteShortcut = (Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control && e.Key == Key.V;
             if (!isPasteShortcut)
             {
                 return;
@@ -470,7 +474,7 @@ namespace YASN
             {
                 if (WinFormsClipboard.ContainsImage())
                 {
-                    using var clipboardImage = WinFormsClipboard.GetImage();
+                    using Image? clipboardImage = WinFormsClipboard.GetImage();
                     if (clipboardImage != null)
                     {
                         InsertClipboardImage(clipboardImage);
@@ -493,14 +497,14 @@ namespace YASN
                     return false;
                 }
 
-                var files = System.Windows.Clipboard.GetFileDropList();
+                StringCollection files = System.Windows.Clipboard.GetFileDropList();
                 if (files.Count == 0)
                 {
                     return false;
                 }
 
-                var insertedAny = false;
-                foreach (var path in files.Cast<string>())
+                bool insertedAny = false;
+                foreach (string path in files.Cast<string>())
                 {
                     if (!File.Exists(path))
                     {
@@ -521,7 +525,12 @@ namespace YASN
 
                 return insertedAny;
             }
-            catch (Exception ex)
+            catch (ExternalException ex)
+            {
+                AppLogger.Warn($"Failed to paste clipboard content: {ex.Message}");
+                return false;
+            }
+            catch (InvalidOperationException ex)
             {
                 AppLogger.Warn($"Failed to paste clipboard content: {ex.Message}");
                 return false;
@@ -533,37 +542,56 @@ namespace YASN
             string? destPath = null;
             try
             {
-                var fileName = $"{Guid.NewGuid()}.png";
+                string fileName = $"{Guid.NewGuid()}.png";
                 destPath = Path.GetFullPath(Path.Combine(_imageDirectory, fileName));
 
-                var targetDirectory = Path.GetDirectoryName(destPath);
+                string? targetDirectory = Path.GetDirectoryName(destPath);
                 if (!string.IsNullOrEmpty(targetDirectory))
                 {
                     Directory.CreateDirectory(targetDirectory);
                 }
 
-                using var bitmap = new System.Drawing.Bitmap(image);
+                using Bitmap bitmap = new System.Drawing.Bitmap(image);
                 using (var stream = File.Create(destPath))
                 {
                     bitmap.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
                 }
 
-                var markdown = $"![clipboard-image](note-assets/{NoteData.Id}/{fileName}){Environment.NewLine}";
+                string markdown = $"![clipboard-image](note-assets/{NoteData.Id}/{fileName}){Environment.NewLine}";
                 InsertTextAtCaret(markdown);
             }
-            catch (Exception ex)
+            catch (ExternalException ex)
             {
-                if (!string.IsNullOrEmpty(destPath) && File.Exists(destPath))
-                {
-                    try
-                    {
-                        File.Delete(destPath);
-                    }
-                    catch
-                    {
-                    }
-                }
-
+                TryDeleteGeneratedFile(destPath, "pasting clipboard image");
+                AppLogger.Warn($"Failed to paste image from clipboard: {ex.Message}");
+                MessageBox.Show($"Fail to paste image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (IOException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "pasting clipboard image");
+                AppLogger.Warn($"Failed to paste image from clipboard: {ex.Message}");
+                MessageBox.Show($"Fail to paste image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "pasting clipboard image");
+                AppLogger.Warn($"Failed to paste image from clipboard: {ex.Message}");
+                MessageBox.Show($"Fail to paste image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (NotSupportedException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "pasting clipboard image");
+                AppLogger.Warn($"Failed to paste image from clipboard: {ex.Message}");
+                MessageBox.Show($"Fail to paste image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (ArgumentException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "pasting clipboard image");
+                AppLogger.Warn($"Failed to paste image from clipboard: {ex.Message}");
                 MessageBox.Show($"Fail to paste image: {ex.Message}", "Error",
                     MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -574,38 +602,57 @@ namespace YASN
             string? destPath = null;
             try
             {
-                var fileName = $"{Guid.NewGuid()}.png";
+                string fileName = $"{Guid.NewGuid()}.png";
                 destPath = Path.GetFullPath(Path.Combine(_imageDirectory, fileName));
 
-                var targetDirectory = Path.GetDirectoryName(destPath);
+                string? targetDirectory = Path.GetDirectoryName(destPath);
                 if (!string.IsNullOrEmpty(targetDirectory))
                 {
                     Directory.CreateDirectory(targetDirectory);
                 }
 
-                var encoder = new PngBitmapEncoder();
+                PngBitmapEncoder encoder = new PngBitmapEncoder();
                 encoder.Frames.Add(BitmapFrame.Create(imageSource));
                 using (var stream = File.Create(destPath))
                 {
                     encoder.Save(stream);
                 }
 
-                var markdown = $"![clipboard-image](note-assets/{NoteData.Id}/{fileName}){Environment.NewLine}";
+                string markdown = $"![clipboard-image](note-assets/{NoteData.Id}/{fileName}){Environment.NewLine}";
                 InsertTextAtCaret(markdown);
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
-                if (!string.IsNullOrEmpty(destPath) && File.Exists(destPath))
-                {
-                    try
-                    {
-                        File.Delete(destPath);
-                    }
-                    catch
-                    {
-                    }
-                }
-
+                TryDeleteGeneratedFile(destPath, "pasting clipboard image");
+                AppLogger.Warn($"Failed to paste image from clipboard: {ex.Message}");
+                MessageBox.Show($"Fail to paste image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "pasting clipboard image");
+                AppLogger.Warn($"Failed to paste image from clipboard: {ex.Message}");
+                MessageBox.Show($"Fail to paste image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (NotSupportedException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "pasting clipboard image");
+                AppLogger.Warn($"Failed to paste image from clipboard: {ex.Message}");
+                MessageBox.Show($"Fail to paste image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (ArgumentException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "pasting clipboard image");
+                AppLogger.Warn($"Failed to paste image from clipboard: {ex.Message}");
+                MessageBox.Show($"Fail to paste image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (InvalidOperationException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "pasting clipboard image");
+                AppLogger.Warn($"Failed to paste image from clipboard: {ex.Message}");
                 MessageBox.Show($"Fail to paste image: {ex.Message}", "Error",
                     MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -628,7 +675,7 @@ namespace YASN
             try
             {
                 PreviewWebView.DefaultBackgroundColor = DrawingColor.Transparent;
-                await PreviewWebView.EnsureCoreWebView2Async();
+                await PreviewWebView.EnsureCoreWebView2Async().ConfigureAwait(false);
                 PreviewWebView.CoreWebView2.Settings.IsStatusBarEnabled = false;
                 PreviewWebView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
 #if DEBUG
@@ -636,7 +683,7 @@ namespace YASN
 #else
                 PreviewWebView.CoreWebView2.Settings.AreDevToolsEnabled = false;
 #endif
-                await PreviewWebView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(PreviewRightClickBridgeScript);
+                await PreviewWebView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(PreviewRightClickBridgeScript).ConfigureAwait(false);
                 PreviewWebView.CoreWebView2.ContextMenuRequested += PreviewCoreWebView2_ContextMenuRequested;
                 PreviewWebView.CoreWebView2.NavigationStarting += PreviewCoreWebView2_NavigationStarting;
                 PreviewWebView.CoreWebView2.WebMessageReceived += PreviewCoreWebView2_WebMessageReceived;
@@ -648,9 +695,17 @@ namespace YASN
 
                 _previewReady = true;
                 ApplyPreviewClip();
-                await RenderPreviewAsync();
+                await RenderPreviewAsync().ConfigureAwait(false);
             }
-            catch (Exception ex)
+            catch (COMException ex)
+            {
+                AppLogger.Warn($"Failed to initialize WebView2: {ex.Message}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Warn($"Failed to initialize WebView2: {ex.Message}");
+            }
+            catch (NotSupportedException ex)
             {
                 AppLogger.Warn($"Failed to initialize WebView2: {ex.Message}");
             }
@@ -669,30 +724,30 @@ namespace YASN
 
             try
             {
-                var shouldTrackEditorCaret = ContentTextBox.Visibility == Visibility.Visible &&
+                bool shouldTrackEditorCaret = ContentTextBox.Visibility == Visibility.Visible &&
                                              ContentTextBox.IsKeyboardFocusWithin;
-                var scrollRatio = shouldTrackEditorCaret
+                double scrollRatio = shouldTrackEditorCaret
                     ? GetEditorCaretScrollRatio()
-                    : await CapturePreviewScrollRatioAsync();
+                    : await CapturePreviewScrollRatioAsync().ConfigureAwait(false);
                 _hasPendingPreviewScrollRestore = scrollRatio >= 0;
                 _pendingPreviewScrollRatio = scrollRatio;
 
-                var markdown = GetContent();
-                var htmlBody = global::Markdig.Markdown.ToHtml(markdown ?? string.Empty, _markdownPipeline);
-                var stylePath = PreviewStyleManager.ToStyleAbsolutePath(_previewStyleRelativePath);
-                var styleVersion = File.Exists(stylePath) ? GetStyleCacheToken(stylePath) : DateTime.UtcNow.Ticks;
-                var styleHref = PreviewStyleManager.BuildStyleHref(_previewStyleRelativePath, styleVersion);
+                string markdown = GetContent();
+                string htmlBody = global::Markdig.Markdown.ToHtml(markdown ?? string.Empty, _markdownPipeline);
+                string stylePath = PreviewStyleManager.ToStyleAbsolutePath(_previewStyleRelativePath);
+                long styleVersion = File.Exists(stylePath) ? GetStyleCacheToken(stylePath) : DateTime.UtcNow.Ticks;
+                string styleHref = PreviewStyleManager.BuildStyleHref(_previewStyleRelativePath, styleVersion);
 
                 if (_isPreviewDocumentReady)
                 {
-                    await UpdatePreviewDocumentAsync(htmlBody, NoteData.IsDarkMode, styleHref, scrollRatio);
+                    await UpdatePreviewDocumentAsync(htmlBody, NoteData.IsDarkMode, styleHref, scrollRatio).ConfigureAwait(false);
                     _hasPendingPreviewScrollRestore = false;
                     return;
                 }
 
-                var html = BuildHtmlPage(htmlBody, NoteData.IsDarkMode, styleHref);
+                string html = BuildHtmlPage(htmlBody, NoteData.IsDarkMode, styleHref);
 
-                var cacheDir = Path.GetDirectoryName(_htmlCachePath);
+                string? cacheDir = Path.GetDirectoryName(_htmlCachePath);
                 if (!string.IsNullOrEmpty(cacheDir))
                 {
                     Directory.CreateDirectory(cacheDir);
@@ -702,13 +757,28 @@ namespace YASN
                 PreviewContainer.Opacity = 0;
                 PreviewWebView.NavigateToString(html);
             }
-            catch (Exception ex)
+            catch (COMException ex)
+            {
+                PreviewContainer.Opacity = 1;
+                AppLogger.Warn($"Failed to render markdown preview: {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                PreviewContainer.Opacity = 1;
+                AppLogger.Warn($"Failed to render markdown preview: {ex.Message}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                PreviewContainer.Opacity = 1;
+                AppLogger.Warn($"Failed to render markdown preview: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
             {
                 PreviewContainer.Opacity = 1;
                 AppLogger.Warn($"Failed to render markdown preview: {ex.Message}");
             }
 
-            await Task.CompletedTask;
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
         private async Task UpdatePreviewDocumentAsync(string htmlBody, bool darkMode, string styleHref, double scrollRatio)
@@ -718,34 +788,34 @@ namespace YASN
                 return;
             }
 
-            var themeClass = darkMode ? "theme-dark" : "theme-light";
-            var htmlJson = JsonSerializer.Serialize(htmlBody ?? string.Empty);
-            var themeJson = JsonSerializer.Serialize(themeClass);
-            var styleJson = JsonSerializer.Serialize(styleHref);
-            var ratioLiteral = scrollRatio.ToString("0.########", CultureInfo.InvariantCulture);
+            string themeClass = darkMode ? "theme-dark" : "theme-light";
+            string htmlJson = JsonSerializer.Serialize(htmlBody ?? string.Empty);
+            string themeJson = JsonSerializer.Serialize(themeClass);
+            string styleJson = JsonSerializer.Serialize(styleHref);
+            string ratioLiteral = scrollRatio.ToString("0.########", CultureInfo.InvariantCulture);
 
-            var script = $"(() => {{ const html = {htmlJson}; const theme = {themeJson}; const styleHref = {styleJson}; const ratio = {ratioLiteral}; const stickToBottom = ratio >= 0.999; const root = document.scrollingElement || document.documentElement || document.body; const page = document.getElementById('page'); if (!root || !page) return; document.body.className = theme; const style = document.getElementById('yasn-style'); if (style && style.getAttribute('href') !== styleHref) style.setAttribute('href', styleHref); page.innerHTML = html; const apply = () => {{ const max = Math.max(0, root.scrollHeight - root.clientHeight); const target = stickToBottom ? max : Math.max(0, Math.min(1, ratio)) * max; if (typeof root.scrollTo === 'function') {{ root.scrollTo({{ top: target, behavior: stickToBottom ? 'auto' : 'smooth' }}); }} else {{ root.scrollTop = target; }} }}; apply(); requestAnimationFrame(apply); setTimeout(apply, 80); }})();";
-            await PreviewWebView.ExecuteScriptAsync(script);
+            string script = $"(() => {{ const html = {htmlJson}; const theme = {themeJson}; const styleHref = {styleJson}; const ratio = {ratioLiteral}; const stickToBottom = ratio >= 0.999; const root = document.scrollingElement || document.documentElement || document.body; const page = document.getElementById('page'); if (!root || !page) return; document.body.className = theme; const style = document.getElementById('yasn-style'); if (style && style.getAttribute('href') !== styleHref) style.setAttribute('href', styleHref); page.innerHTML = html; const apply = () => {{ const max = Math.max(0, root.scrollHeight - root.clientHeight); const target = stickToBottom ? max : Math.max(0, Math.min(1, ratio)) * max; if (typeof root.scrollTo === 'function') {{ root.scrollTo({{ top: target, behavior: stickToBottom ? 'auto' : 'smooth' }}); }} else {{ root.scrollTop = target; }} }}; apply(); requestAnimationFrame(apply); setTimeout(apply, 80); }})();";
+            await PreviewWebView.ExecuteScriptAsync(script).ConfigureAwait(false);
         }
 
         private double GetEditorCaretScrollRatio()
         {
             try
             {
-                var textLength = ContentTextBox.Text?.Length ?? 0;
+                int textLength = ContentTextBox.Text?.Length ?? 0;
                 if (textLength <= 0)
                 {
                     return 0;
                 }
 
-                var lineCount = Math.Max(1, ContentTextBox.LineCount);
+                int lineCount = Math.Max(1, ContentTextBox.LineCount);
                 if (lineCount <= 1)
                 {
                     return 0;
                 }
 
-                var caretLine = ContentTextBox.GetLineIndexFromCharacterIndex(ContentTextBox.CaretIndex);
-                var lastLine = lineCount - 1;
+                int caretLine = ContentTextBox.GetLineIndexFromCharacterIndex(ContentTextBox.CaretIndex);
+                int lastLine = lineCount - 1;
 
                 // When editing at document end (new appended lines), force preview to follow to bottom.
                 if (ContentTextBox.CaretIndex >= textLength - 1 || caretLine >= lastLine - 1)
@@ -753,11 +823,17 @@ namespace YASN
                     return 1;
                 }
 
-                var ratio = caretLine / (double)(lineCount - 1);
+                double ratio = caretLine / (double)(lineCount - 1);
                 return Math.Clamp(ratio, 0, 1);
             }
-            catch
+            catch (ArgumentOutOfRangeException ex)
             {
+                AppLogger.Debug($"Failed to compute editor caret scroll ratio: {ex.Message}");
+                return 0;
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Debug($"Failed to compute editor caret scroll ratio: {ex.Message}");
                 return 0;
             }
         }
@@ -771,17 +847,28 @@ namespace YASN
 
             try
             {
-                var script = "(() => { const root = document.scrollingElement || document.documentElement || document.body; if (!root) return -1; const max = Math.max(0, root.scrollHeight - root.clientHeight); if (max <= 0) return 0; const top = root.scrollTop || window.scrollY || 0; return top / max; })();";
-                var raw = await PreviewWebView.ExecuteScriptAsync(script);
-                if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var ratio))
+                string script = "(() => { const root = document.scrollingElement || document.documentElement || document.body; if (!root) return -1; const max = Math.max(0, root.scrollHeight - root.clientHeight); if (max <= 0) return 0; const top = root.scrollTop || window.scrollY || 0; return top / max; })();";
+                string raw = await PreviewWebView.ExecuteScriptAsync(script).ConfigureAwait(false);
+                if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out double ratio))
                 {
                     return -1;
                 }
 
                 return Math.Clamp(ratio, 0, 1);
             }
-            catch
+            catch (COMException ex)
             {
+                AppLogger.Debug($"Failed to capture preview scroll ratio: {ex.Message}");
+                return -1;
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Debug($"Failed to capture preview scroll ratio: {ex.Message}");
+                return -1;
+            }
+            catch (TaskCanceledException ex)
+            {
+                AppLogger.Debug($"Failed to capture preview scroll ratio: {ex.Message}");
                 return -1;
             }
         }
@@ -808,13 +895,21 @@ namespace YASN
 
             try
             {
-                var ratioLiteral = _pendingPreviewScrollRatio.ToString("0.########", CultureInfo.InvariantCulture);
-                var script = $"(() => {{ const ratio = {ratioLiteral}; const stickToBottom = ratio >= 0.999; const root = document.scrollingElement || document.documentElement || document.body; if (!root) return; const apply = () => {{ const max = Math.max(0, root.scrollHeight - root.clientHeight); const target = stickToBottom ? max : max * Math.max(0, Math.min(1, ratio)); if (typeof root.scrollTo === 'function') {{ root.scrollTo({{ top: target, behavior: stickToBottom ? 'auto' : 'smooth' }}); }} else {{ root.scrollTop = target; }} }}; apply(); requestAnimationFrame(apply); setTimeout(apply, 80); }})();";
-                await PreviewWebView.ExecuteScriptAsync(script);
+                string ratioLiteral = _pendingPreviewScrollRatio.ToString("0.########", CultureInfo.InvariantCulture);
+                string script = $"(() => {{ const ratio = {ratioLiteral}; const stickToBottom = ratio >= 0.999; const root = document.scrollingElement || document.documentElement || document.body; if (!root) return; const apply = () => {{ const max = Math.max(0, root.scrollHeight - root.clientHeight); const target = stickToBottom ? max : max * Math.max(0, Math.min(1, ratio)); if (typeof root.scrollTo === 'function') {{ root.scrollTo({{ top: target, behavior: stickToBottom ? 'auto' : 'smooth' }}); }} else {{ root.scrollTop = target; }} }}; apply(); requestAnimationFrame(apply); setTimeout(apply, 80); }})();";
+                await PreviewWebView.ExecuteScriptAsync(script).ConfigureAwait(false);
             }
-            catch
+            catch (COMException ex)
             {
-                // ignore restore failures
+                AppLogger.Debug($"Failed to restore preview scroll position: {ex.Message}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Debug($"Failed to restore preview scroll position: {ex.Message}");
+            }
+            catch (TaskCanceledException ex)
+            {
+                AppLogger.Debug($"Failed to restore preview scroll position: {ex.Message}");
             }
             finally
             {
@@ -824,7 +919,7 @@ namespace YASN
 
         private static string BuildHtmlPage(string htmlBody, bool darkMode, string styleHref)
         {
-            var themeClass = darkMode ? "theme-dark" : "theme-light";
+            string themeClass = darkMode ? "theme-dark" : "theme-light";
 
             return $@"<!doctype html>
 <html>
@@ -846,18 +941,24 @@ namespace YASN
         {
             try
             {
-                var info = new FileInfo(stylePath);
+                FileInfo info = new FileInfo(stylePath);
                 return info.LastWriteTimeUtc.Ticks ^ info.Length;
             }
-            catch
+            catch (IOException ex)
             {
+                AppLogger.Debug($"Failed to compute style cache token for '{stylePath}': {ex.Message}");
+                return DateTime.UtcNow.Ticks;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to compute style cache token for '{stylePath}': {ex.Message}");
                 return DateTime.UtcNow.Ticks;
             }
         }
 
         private void InsertImage_Click(object sender, RoutedEventArgs e)
         {
-            var openFileDialog = new OpenFileDialog
+            OpenFileDialog openFileDialog = new OpenFileDialog
             {
                 Filter = "Image File|*.png;*.jpg;*.jpeg;*.gif;*.bmp;*.webp",
                 Title = "Select Image to Insert"
@@ -871,7 +972,7 @@ namespace YASN
 
         private void InsertAttachment_Click(object sender, RoutedEventArgs e)
         {
-            var openFileDialog = new OpenFileDialog
+            OpenFileDialog openFileDialog = new OpenFileDialog
             {
                 Filter = "All Files|*.*",
                 Title = "Select Attachment to Insert"
@@ -887,7 +988,7 @@ namespace YASN
         {
             if (e.Data.GetDataPresent(DataFormats.FileDrop))
             {
-                var files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
                 if (files != null && files.Length > 0 && File.Exists(files[0]))
                 {
                     e.Effects = DragDropEffects.Copy;
@@ -902,30 +1003,53 @@ namespace YASN
 
         private void ContentTextBox_PreviewDrop(object sender, DragEventArgs e)
         {
-            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            if (!e.Data.GetDataPresent(DataFormats.FileDrop)) return;
+            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+            if (files != null && files.Length > 0 && File.Exists(files[0]))
             {
-                var files = (string[])e.Data.GetData(DataFormats.FileDrop);
-                if (files != null && files.Length > 0 && File.Exists(files[0]))
+                if (IsImageFile(files[0]))
                 {
-                    if (IsImageFile(files[0]))
-                    {
-                        InsertImage(files[0]);
-                    }
-                    else
-                    {
-                        InsertAttachment(files[0]);
-                    }
-
-                    e.Handled = true;
+                    InsertImage(files[0]);
                 }
+                else
+                {
+                    InsertAttachment(files[0]);
+                }
+
+                e.Handled = true;
             }
         }
 
         private static bool IsImageFile(string filePath)
         {
-            var extension = Path.GetExtension(filePath).ToLowerInvariant();
-            return extension == ".png" || extension == ".jpg" || extension == ".jpeg" ||
-                   extension == ".gif" || extension == ".bmp" || extension == ".webp";
+            string extension = Path.GetExtension(filePath);
+            return string.Equals(extension, ".png", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".jpg", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".jpeg", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".gif", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".bmp", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(extension, ".webp", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void TryDeleteGeneratedFile(string? path, string reason)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            {
+                return;
+            }
+
+            try
+            {
+                File.Delete(path);
+            }
+            catch (IOException ex)
+            {
+                AppLogger.Debug($"Failed to clean up generated file '{path}' after {reason}: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to clean up generated file '{path}' after {reason}: {ex.Message}");
+            }
         }
 
         private void InsertImage(string sourceFilePath)
@@ -933,29 +1057,41 @@ namespace YASN
             string destPath = null;
             try
             {
-                var fileName = $"{Guid.NewGuid()}{Path.GetExtension(sourceFilePath)}";
+                string fileName = $"{Guid.NewGuid()}{Path.GetExtension(sourceFilePath)}";
                 destPath = Path.Combine(_imageDirectory, fileName);
                 File.Copy(sourceFilePath, destPath, true);
 
-                var relativePath = $"note-assets/{NoteData.Id}/{fileName}";
-                var altText = Path.GetFileNameWithoutExtension(sourceFilePath);
-                var markdown = $"![{altText}]({relativePath}){Environment.NewLine}";
+                string relativePath = $"note-assets/{NoteData.Id}/{fileName}";
+                string altText = Path.GetFileNameWithoutExtension(sourceFilePath);
+                string markdown = $"![{altText}]({relativePath}){Environment.NewLine}";
 
                 InsertTextAtCaret(markdown);
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
-                if (destPath != null && File.Exists(destPath))
-                {
-                    try
-                    {
-                        File.Delete(destPath);
-                    }
-                    catch
-                    {
-                    }
-                }
-
+                TryDeleteGeneratedFile(destPath, "inserting image");
+                AppLogger.Warn($"Failed to insert image '{sourceFilePath}': {ex.Message}");
+                MessageBox.Show($"Fail to insert image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "inserting image");
+                AppLogger.Warn($"Failed to insert image '{sourceFilePath}': {ex.Message}");
+                MessageBox.Show($"Fail to insert image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (NotSupportedException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "inserting image");
+                AppLogger.Warn($"Failed to insert image '{sourceFilePath}': {ex.Message}");
+                MessageBox.Show($"Fail to insert image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (ArgumentException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "inserting image");
+                AppLogger.Warn($"Failed to insert image '{sourceFilePath}': {ex.Message}");
                 MessageBox.Show($"Fail to insert image: {ex.Message}", "Error",
                     MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -972,17 +1108,17 @@ namespace YASN
 
             try
             {
-                var fileInfo = new FileInfo(sourceFilePath);
-                var displayName = Path.GetFileName(sourceFilePath);
+                FileInfo fileInfo = new FileInfo(sourceFilePath);
+                string displayName = Path.GetFileName(sourceFilePath);
                 string linkTarget;
-                var settingsStore = new SettingsStore();
-                var autoSyncEnabled = AttachmentSyncSettings.GetAutoSyncEnabled(settingsStore);
-                var autoSyncMaxBytes = AttachmentSyncSettings.GetAutoSyncThresholdBytes(settingsStore);
+                SettingsStore settingsStore = new SettingsStore();
+                bool autoSyncEnabled = AttachmentSyncSettings.GetAutoSyncEnabled(settingsStore);
+                long autoSyncMaxBytes = AttachmentSyncSettings.GetAutoSyncThresholdBytes(settingsStore);
 
                 if (autoSyncEnabled && fileInfo.Length <= autoSyncMaxBytes)
                 {
-                    var fileName = $"{Guid.NewGuid()}{Path.GetExtension(sourceFilePath)}";
-                    var destPath = Path.Combine(_attachmentDirectory, fileName);
+                    string fileName = $"{Guid.NewGuid()}{Path.GetExtension(sourceFilePath)}";
+                    string destPath = Path.Combine(_attachmentDirectory, fileName);
                     File.Copy(sourceFilePath, destPath, true);
                     linkTarget = $"note-assets/attachments/{NoteData.Id}/{fileName}";
                 }
@@ -991,11 +1127,30 @@ namespace YASN
                     linkTarget = new Uri(sourceFilePath, UriKind.Absolute).AbsoluteUri;
                 }
 
-                var markdown = $"[{displayName}]({linkTarget}){Environment.NewLine}";
+                string markdown = $"[{displayName}]({linkTarget}){Environment.NewLine}";
                 InsertTextAtCaret(markdown);
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
+                AppLogger.Warn($"Failed to insert attachment '{sourceFilePath}': {ex.Message}");
+                MessageBox.Show($"Fail to insert attachment: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Warn($"Failed to insert attachment '{sourceFilePath}': {ex.Message}");
+                MessageBox.Show($"Fail to insert attachment: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (UriFormatException ex)
+            {
+                AppLogger.Warn($"Failed to insert attachment '{sourceFilePath}': {ex.Message}");
+                MessageBox.Show($"Fail to insert attachment: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (ArgumentException ex)
+            {
+                AppLogger.Warn($"Failed to insert attachment '{sourceFilePath}': {ex.Message}");
                 MessageBox.Show($"Fail to insert attachment: {ex.Message}", "Error",
                     MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -1003,8 +1158,8 @@ namespace YASN
 
         private void InsertTextAtCaret(string text)
         {
-            var index = ContentTextBox.CaretIndex;
-            var current = ContentTextBox.Text ?? string.Empty;
+            int index = ContentTextBox.CaretIndex;
+            string current = ContentTextBox.Text ?? string.Empty;
             ContentTextBox.Text = current.Insert(index, text);
             ContentTextBox.CaretIndex = index + text.Length;
             ContentTextBox.Focus();
@@ -1041,8 +1196,8 @@ namespace YASN
 
         public void RefreshTaskbarVisibilityFromSettings()
         {
-            var settingsStore = new SettingsStore();
-            var modeValue = settingsStore.GetValue(
+            SettingsStore settingsStore = new SettingsStore();
+            string modeValue = settingsStore.GetValue(
                 FloatingWindowTaskbarVisibility.SettingKey,
                 shouldSync: true,
                 defaultValue: FloatingWindowTaskbarVisibility.DefaultValue);
@@ -1052,13 +1207,13 @@ namespace YASN
 
         public void RefreshPreviewStyleFromSettings(bool forceRender = true)
         {
-            var settingsStore = new SettingsStore();
-            var selectedStyle = settingsStore.GetValue(
+            SettingsStore settingsStore = new SettingsStore();
+            string selectedStyle = settingsStore.GetValue(
                 PreviewStyleManager.SettingKey,
                 shouldSync: false,
                 defaultValue: PreviewStyleManager.DefaultStyleRelativePath);
-            var resolvedStyle = PreviewStyleManager.ResolveStyle(selectedStyle);
-            var hasChanged = !string.Equals(_previewStyleRelativePath, resolvedStyle, StringComparison.OrdinalIgnoreCase);
+            string resolvedStyle = PreviewStyleManager.ResolveStyle(selectedStyle);
+            bool hasChanged = !string.Equals(_previewStyleRelativePath, resolvedStyle, StringComparison.OrdinalIgnoreCase);
             if (hasChanged)
             {
                 AppLogger.Debug($"Note {NoteData.Id} preview style changed: '{_previewStyleRelativePath}' -> '{resolvedStyle}'.");
@@ -1081,8 +1236,8 @@ namespace YASN
                 _debugSourceStyleWatcher?.Dispose();
                 _debugSourceStyleWatcher = null;
 
-                var activeStylePath = PreviewStyleManager.ToStyleAbsolutePath(_previewStyleRelativePath);
-                var activeDirectory = Path.GetDirectoryName(activeStylePath);
+                string activeStylePath = PreviewStyleManager.ToStyleAbsolutePath(_previewStyleRelativePath);
+                string? activeDirectory = Path.GetDirectoryName(activeStylePath);
                 if (!string.IsNullOrEmpty(activeDirectory))
                 {
                     Directory.CreateDirectory(activeDirectory);
@@ -1101,41 +1256,52 @@ namespace YASN
                 }
 
 #if DEBUG
-                var sourceStylePath = TryResolveDebugSourceStylePath(_previewStyleRelativePath);
-                if (!string.IsNullOrEmpty(sourceStylePath) &&
-                    !string.Equals(sourceStylePath, activeStylePath, StringComparison.OrdinalIgnoreCase) &&
-                    File.Exists(sourceStylePath))
+                string? sourceStylePath = TryResolveDebugSourceStylePath(_previewStyleRelativePath);
+                if (string.IsNullOrEmpty(sourceStylePath) ||
+                    string.Equals(sourceStylePath, activeStylePath, StringComparison.OrdinalIgnoreCase) ||
+                    !File.Exists(sourceStylePath)) return;
                 {
-                    var sourceDirectory = Path.GetDirectoryName(sourceStylePath);
-                    if (!string.IsNullOrEmpty(sourceDirectory))
+                    string? sourceDirectory = Path.GetDirectoryName(sourceStylePath);
+                    if (string.IsNullOrEmpty(sourceDirectory)) return;
+                    _debugSourceStyleWatcher = new FileSystemWatcher(sourceDirectory, Path.GetFileName(sourceStylePath))
                     {
-                        _debugSourceStyleWatcher = new FileSystemWatcher(sourceDirectory, Path.GetFileName(sourceStylePath))
-                        {
-                            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.CreationTime | NotifyFilters.FileName,
-                            EnableRaisingEvents = true
-                        };
+                        NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size | NotifyFilters.CreationTime | NotifyFilters.FileName,
+                        EnableRaisingEvents = true
+                    };
 
-                        void SyncAndRefresh()
+                    void SyncAndRefresh()
+                    {
+                        try
                         {
-                            try
-                            {
-                                File.Copy(sourceStylePath, activeStylePath, overwrite: true);
-                            }
-                            catch
-                            {
-                            }
-
-                            QueuePreviewStyleRefresh();
+                            File.Copy(sourceStylePath, activeStylePath, overwrite: true);
+                        }
+                        catch (IOException ex)
+                        {
+                            AppLogger.Debug($"Failed to sync preview style from '{sourceStylePath}' to '{activeStylePath}': {ex.Message}");
+                        }
+                        catch (UnauthorizedAccessException ex)
+                        {
+                            AppLogger.Debug($"Failed to sync preview style from '{sourceStylePath}' to '{activeStylePath}': {ex.Message}");
                         }
 
-                        _debugSourceStyleWatcher.Changed += (_, _) => SyncAndRefresh();
-                        _debugSourceStyleWatcher.Created += (_, _) => SyncAndRefresh();
-                        _debugSourceStyleWatcher.Renamed += (_, _) => SyncAndRefresh();
+                        QueuePreviewStyleRefresh();
                     }
+
+                    _debugSourceStyleWatcher.Changed += (_, _) => SyncAndRefresh();
+                    _debugSourceStyleWatcher.Created += (_, _) => SyncAndRefresh();
+                    _debugSourceStyleWatcher.Renamed += (_, _) => SyncAndRefresh();
                 }
 #endif
             }
-            catch (Exception ex)
+            catch (IOException ex)
+            {
+                AppLogger.Warn($"Failed to configure preview style watcher: {ex.Message}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Warn($"Failed to configure preview style watcher: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
             {
                 AppLogger.Warn($"Failed to configure preview style watcher: {ex.Message}");
             }
@@ -1154,24 +1320,33 @@ namespace YASN
         {
             try
             {
-                var baseDir = new DirectoryInfo(AppPaths.BaseDirectory);
-                for (var current = baseDir; current != null; current = current.Parent)
+                DirectoryInfo baseDir = new DirectoryInfo(AppPaths.BaseDirectory);
+                for (DirectoryInfo? current = baseDir; current != null; current = current.Parent)
                 {
-                    var csproj = Path.Combine(current.FullName, "YASN.csproj");
+                    string csproj = Path.Combine(current.FullName, "YASN.csproj");
                     if (!File.Exists(csproj))
                     {
                         continue;
                     }
 
-                    var candidate = Path.Combine(current.FullName, "style", relativeStylePath.Replace('/', Path.DirectorySeparatorChar));
+                    string candidate = Path.Combine(current.FullName, "style", relativeStylePath.Replace('/', Path.DirectorySeparatorChar));
                     if (File.Exists(candidate))
                     {
                         return candidate;
                     }
                 }
             }
-            catch
+            catch (IOException ex)
             {
+                AppLogger.Debug($"Failed to resolve debug preview style path '{relativeStylePath}': {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to resolve debug preview style path '{relativeStylePath}': {ex.Message}");
+            }
+            catch (ArgumentException ex)
+            {
+                AppLogger.Debug($"Failed to resolve debug preview style path '{relativeStylePath}': {ex.Message}");
             }
 
             return null;
@@ -1192,7 +1367,7 @@ namespace YASN
             _hwnd = new WindowInteropHelper(this).Handle;
             RefreshTaskbarVisibilityFromSettings();
             ApplyWindowLevel();
-            await InitializePreviewAsync();
+            await InitializePreviewAsync().ConfigureAwait(false);
             SchedulePreviewRender();
             UpdateChromeBarsByMouseState();
         }
@@ -1220,7 +1395,7 @@ namespace YASN
         private void FloatingWindow_PreviewKeyDown(object sender, KeyEventArgs e)
         {
 #if DEBUG
-            var isOpenDevToolsShortcut = e.Key == Key.F12 ||
+            bool isOpenDevToolsShortcut = e.Key == Key.F12 ||
                                          (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift) && e.Key == Key.I);
             if (isOpenDevToolsShortcut)
             {
@@ -1228,7 +1403,11 @@ namespace YASN
                 {
                     PreviewWebView.CoreWebView2?.OpenDevToolsWindow();
                 }
-                catch (Exception ex)
+                catch (COMException ex)
+                {
+                    AppLogger.Warn($"Failed to open WebView2 DevTools: {ex.Message}");
+                }
+                catch (InvalidOperationException ex)
                 {
                     AppLogger.Warn($"Failed to open WebView2 DevTools: {ex.Message}");
                 }
@@ -1260,9 +1439,9 @@ namespace YASN
                 return;
             }
 
-            var now = DateTime.UtcNow;
-            var threshold = TimeSpan.FromMilliseconds(900);
-            var isDoubleRightClick = now - _lastPreviewSurfaceRightClickUtc <= threshold;
+            DateTime now = DateTime.UtcNow;
+            TimeSpan threshold = TimeSpan.FromMilliseconds(900);
+            bool isDoubleRightClick = now - _lastPreviewSurfaceRightClickUtc <= threshold;
             _lastPreviewSurfaceRightClickUtc = now;
             if (!isDoubleRightClick)
             {
@@ -1281,9 +1460,9 @@ namespace YASN
                 return;
             }
 
-            var now = DateTime.UtcNow;
-            var threshold = TimeSpan.FromMilliseconds(900);
-            var isDoubleRightClick = now - _lastPreviewRightClickUtc <= threshold;
+            DateTime now = DateTime.UtcNow;
+            TimeSpan threshold = TimeSpan.FromMilliseconds(900);
+            bool isDoubleRightClick = now - _lastPreviewRightClickUtc <= threshold;
             _lastPreviewRightClickUtc = now;
 
             e.Handled = true;
@@ -1308,8 +1487,14 @@ namespace YASN
             {
                 message = e.TryGetWebMessageAsString();
             }
-            catch
+            catch (COMException ex)
             {
+                AppLogger.Debug($"Failed to read preview web message: {ex.Message}");
+                return;
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Debug($"Failed to read preview web message: {ex.Message}");
                 return;
             }
 
@@ -1328,7 +1513,7 @@ namespace YASN
                 return;
             }
 
-            if (!TryResolveOpenTarget(e.Uri, out var openTarget))
+            if (!TryResolveOpenTarget(e.Uri, out string? openTarget))
             {
                 return;
             }
@@ -1349,7 +1534,7 @@ namespace YASN
             {
                 if (uri.IsFile)
                 {
-                    var localPath = uri.LocalPath;
+                    string localPath = uri.LocalPath;
                     if (File.Exists(localPath))
                     {
                         openTarget = localPath;
@@ -1359,9 +1544,9 @@ namespace YASN
                 else if (string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase) &&
                          string.Equals(uri.Host, "yasn.local", StringComparison.OrdinalIgnoreCase))
                 {
-                    var localRelative = Uri.UnescapeDataString(uri.AbsolutePath.TrimStart('/'))
+                    string localRelative = Uri.UnescapeDataString(uri.AbsolutePath.TrimStart('/'))
                         .Replace('/', Path.DirectorySeparatorChar);
-                    var localPath = Path.Combine(AppPaths.DataDirectory, localRelative);
+                    string localPath = Path.Combine(AppPaths.DataDirectory, localRelative);
                     if (File.Exists(localPath))
                     {
                         openTarget = localPath;
@@ -1389,15 +1574,28 @@ namespace YASN
         {
             try
             {
-                var startInfo = new ProcessStartInfo
+                ProcessStartInfo startInfo = new ProcessStartInfo
                 {
                     FileName = target,
                     UseShellExecute = true
                 };
                 Process.Start(startInfo);
             }
-            catch (Exception ex)
+            catch (Win32Exception ex)
             {
+                AppLogger.Warn($"Failed to open target '{target}': {ex.Message}");
+                MessageBox.Show($"Fail to open attachment: {ex.Message}", "Open Failed",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (FileNotFoundException ex)
+            {
+                AppLogger.Warn($"Failed to open target '{target}': {ex.Message}");
+                MessageBox.Show($"Fail to open attachment: {ex.Message}", "Open Failed",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Warn($"Failed to open target '{target}': {ex.Message}");
                 MessageBox.Show($"Fail to open attachment: {ex.Message}", "Open Failed",
                     MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -1439,56 +1637,52 @@ namespace YASN
                 return;
             }
 
-            var contextMenu = new ContextMenu();
+            ContextMenu contextMenu = new ContextMenu();
 
-            var renameTitleItem = new MenuItem { Header = "Edit Title" };
+            MenuItem renameTitleItem = new MenuItem { Header = "Edit Title" };
             renameTitleItem.Click += (_, _) => PromptRenameTitle();
 
-            var showMainWindowItem = new MenuItem { Header = "Open MainWindow" };
+            MenuItem showMainWindowItem = new MenuItem { Header = "Open MainWindow" };
             showMainWindowItem.Click += (_, _) =>
             {
-                if (Application.Current is App app && app.MainWindow != null)
-                {
-                    app.MainWindow.Show();
-                    app.MainWindow.WindowState = WindowState.Normal;
-                    app.MainWindow.Activate();
-                }
+                if (Application.Current is not App app || app.MainWindow == null) return;
+                app.MainWindow.Show();
+                app.MainWindow.WindowState = WindowState.Normal;
+                app.MainWindow.Activate();
             };
 
-            var createNoteItem = new MenuItem { Header = "Create New Note" };
+            MenuItem createNoteItem = new MenuItem { Header = "Create New Note" };
             createNoteItem.Click += (_, _) =>
             {
-                var newNote = NoteManager.Instance.CreateNote();
+                NoteData newNote = NoteManager.Instance.CreateNote();
                 new FloatingWindow(newNote).Show();
             };
 
-            var createTopMostNoteItem = new MenuItem { Header = "Create TopMost Note" };
+            MenuItem createTopMostNoteItem = new MenuItem { Header = "Create TopMost Note" };
             createTopMostNoteItem.Click += (_, _) =>
             {
-                var newNote = NoteManager.Instance.CreateNote(WindowLevel.TopMost);
+                NoteData newNote = NoteManager.Instance.CreateNote(WindowLevel.TopMost);
                 new FloatingWindow(newNote).Show();
             };
 
-            var deleteNoteItem = new MenuItem { Header = "Delete Note" };
+            MenuItem deleteNoteItem = new MenuItem { Header = "Delete Note" };
             deleteNoteItem.Click += (_, _) =>
             {
-                var result = MessageBox.Show(
+                MessageBoxResult? result = MessageBox.Show(
                     "Are you sure you want to delete this note?",
                     "Delete",
                     MessageBoxButton.YesNo,
                     MessageBoxImage.Question);
 
-                if (result == MessageBoxResult.Yes)
-                {
-                    NoteManager.Instance.DeleteNote(NoteData);
-                    Close();
-                }
+                if (result != MessageBoxResult.Yes) return;
+                NoteManager.Instance.DeleteNote(NoteData);
+                Close();
             };
 
-            var clearContentItem = new MenuItem { Header = "Clear Content" };
+            MenuItem clearContentItem = new MenuItem { Header = "Clear Content" };
             clearContentItem.Click += (_, _) =>
             {
-                var result = MessageBox.Show(
+                MessageBoxResult? result = MessageBox.Show(
                     "Are you sure you want to clear the current content?",
                     "Clear Content",
                     MessageBoxButton.YesNo,
@@ -1500,13 +1694,13 @@ namespace YASN
                 }
             };
 
-            var changeTitleBarColorItem = new MenuItem { Header = "Change Title Bar Color" };
+            MenuItem changeTitleBarColorItem = new MenuItem { Header = "Change Title Bar Color" };
             changeTitleBarColorItem.Click += (_, _) => ShowColorPicker();
 
-            var backgroundImageItem = new MenuItem { Header = "Background Image" };
+            MenuItem backgroundImageItem = new MenuItem { Header = "Background Image" };
             backgroundImageItem.Click += (_, _) => ShowBackgroundImageMenu(button);
 
-            var aboutItem = new MenuItem { Header = "About" };
+            MenuItem aboutItem = new MenuItem { Header = "About" };
             aboutItem.Click += (_, _) =>
             {
                 MessageBox.Show(
@@ -1606,16 +1800,11 @@ namespace YASN
 
         private void UpdateTitleBarButtons()
         {
-            if (MinimizeButton == null)
-            {
-                return;
-            }
-
-            MinimizeButton.Visibility = NoteData.Level == WindowLevel.Normal
+            MinimizeButton?.Visibility = NoteData.Level == WindowLevel.Normal
                 ? Visibility.Visible
                 : Visibility.Collapsed;
         }
-        
+
         private void ExpandWindowWidthForSplitMode()
         {
             if (WindowState != WindowState.Normal)
@@ -1628,16 +1817,16 @@ namespace YASN
                 _singleModeWidthBeforeSplit = Width;
             }
 
-            var minWidth = MinWidth > 0 ? MinWidth : 320;
-            var targetWidth = Math.Max(minWidth, _singleModeWidthBeforeSplit * 2);
-            var maxWidth = Math.Max(minWidth, SystemParameters.WorkArea.Width - 20);
-            var finalWidth = Math.Min(targetWidth, maxWidth);
+            double minWidth = MinWidth > 0 ? MinWidth : 320;
+            double targetWidth = Math.Max(minWidth, _singleModeWidthBeforeSplit * 2);
+            double maxWidth = Math.Max(minWidth, SystemParameters.WorkArea.Width - 20);
+            double finalWidth = Math.Min(targetWidth, maxWidth);
             if (Math.Abs(finalWidth - Width) <= 1)
             {
                 return;
             }
 
-            var currentWidth = Width;
+            double currentWidth = Width;
             Width = finalWidth;
             AppLogger.Debug($"Auto expand width for split mode: {currentWidth:F0} -> {finalWidth:F0}");
         }
@@ -1649,9 +1838,9 @@ namespace YASN
                 return;
             }
 
-            var minWidth = MinWidth > 0 ? MinWidth : 320;
-            var restoreWidth = Math.Max(minWidth, _singleModeWidthBeforeSplit);
-            var currentWidth = Width;
+            double minWidth = MinWidth > 0 ? MinWidth : 320;
+            double restoreWidth = Math.Max(minWidth, _singleModeWidthBeforeSplit);
+            double currentWidth = Width;
             _singleModeWidthBeforeSplit = double.NaN;
             if (Math.Abs(currentWidth - restoreWidth) <= 1)
             {
@@ -1664,13 +1853,13 @@ namespace YASN
 
         private void PromptRenameTitle()
         {
-            var input = ShowTitleInputDialog(NoteData.Title);
+            string? input = ShowTitleInputDialog(NoteData.Title);
             if (input == null)
             {
                 return;
             }
 
-            var newTitle = input.Trim();
+            string newTitle = input.Trim();
             if (string.IsNullOrEmpty(newTitle))
             {
                 MessageBox.Show(
@@ -1686,7 +1875,7 @@ namespace YASN
                 return;
             }
 
-            var hasDuplicate = NoteManager.Instance.Notes.Any(n =>
+            bool hasDuplicate = NoteManager.Instance.Notes.Any(n =>
                 n.Id != NoteData.Id &&
                 string.Equals((n.Title ?? string.Empty).Trim(), newTitle, StringComparison.OrdinalIgnoreCase));
             if (hasDuplicate)
@@ -1706,7 +1895,7 @@ namespace YASN
 
         private string? ShowTitleInputDialog(string initialValue)
         {
-            var dialog = new Window
+            Window dialog = new Window
             {
                 Title = "Edit Title",
                 Width = 360,
@@ -1717,30 +1906,30 @@ namespace YASN
                 WindowStyle = WindowStyle.ToolWindow
             };
 
-            var grid = new Grid { Margin = new Thickness(14) };
+            Grid grid = new Grid { Margin = new Thickness(14) };
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
             grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
 
-            var prompt = new TextBlock
+            TextBlock prompt = new TextBlock
             {
                 Text = "New Title",
                 Margin = new Thickness(0, 0, 0, 8)
             };
 
-            var inputBox = new System.Windows.Controls.TextBox
+            System.Windows.Controls.TextBox inputBox = new System.Windows.Controls.TextBox
             {
                 Text = initialValue ?? string.Empty,
                 Margin = new Thickness(0, 0, 0, 12)
             };
 
-            var buttonPanel = new StackPanel
+            StackPanel buttonPanel = new StackPanel
             {
                 Orientation = System.Windows.Controls.Orientation.Horizontal,
                 HorizontalAlignment = HorizontalAlignment.Right
             };
 
-            var okButton = new Button
+            Button okButton = new Button
             {
                 Content = "Confirm",
                 Width = 72,
@@ -1748,7 +1937,7 @@ namespace YASN
                 Margin = new Thickness(0, 0, 8, 0)
             };
 
-            var cancelButton = new Button
+            Button cancelButton = new Button
             {
                 Content = "Cancel",
                 Width = 72,
@@ -1790,7 +1979,7 @@ namespace YASN
 
         private void UpdateStatusText()
         {
-            var levelPrefix = NoteData.Level switch
+            string levelPrefix = NoteData.Level switch
             {
                 WindowLevel.TopMost => "[T] ",
                 WindowLevel.BottomMost => "[B] ",
@@ -1823,7 +2012,7 @@ namespace YASN
                     {
                         if (_currentBottomMostWindow != null && _currentBottomMostWindow != this)
                         {
-                            var previousWindow = _currentBottomMostWindow;
+                            FloatingWindow previousWindow = _currentBottomMostWindow;
                             _currentBottomMostWindow = null;
                             previousWindow.Dispatcher.Invoke(() => previousWindow.SetWindowLevel(WindowLevel.Normal));
                         }
@@ -1922,13 +2111,21 @@ namespace YASN
 
             try
             {
-                var themeClass = isDarkMode ? "theme-dark" : "theme-light";
-                var script = $"(() => {{ if (document.body) document.body.className = '{themeClass}'; }})();";
-                await PreviewWebView.ExecuteScriptAsync(script);
+                string themeClass = isDarkMode ? "theme-dark" : "theme-light";
+                string script = $"(() => {{ if (document.body) document.body.className = '{themeClass}'; }})();";
+                await PreviewWebView.ExecuteScriptAsync(script).ConfigureAwait(false);
             }
-            catch
+            catch (COMException ex)
             {
-                // ignore immediate theme apply failures
+                AppLogger.Debug($"Failed to apply preview theme class: {ex.Message}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Debug($"Failed to apply preview theme class: {ex.Message}");
+            }
+            catch (TaskCanceledException ex)
+            {
+                AppLogger.Debug($"Failed to apply preview theme class: {ex.Message}");
             }
         }
 
@@ -1971,17 +2168,23 @@ namespace YASN
         {
             try
             {
-                var color = (Color)ColorConverter.ConvertFromString(colorHex);
+                Color color = (Color)ColorConverter.ConvertFromString(colorHex);
                 TitleBar.Background = new SolidColorBrush(color);
             }
-            catch
+            catch (FormatException ex)
             {
+                AppLogger.Warn($"Failed to apply title bar color '{colorHex}': {ex.Message}");
+                TitleBar.Background = new SolidColorBrush(Color.FromArgb(0xE6, 0xD4, 0xC5, 0xE0));
+            }
+            catch (NotSupportedException ex)
+            {
+                AppLogger.Warn($"Failed to apply title bar color '{colorHex}': {ex.Message}");
                 TitleBar.Background = new SolidColorBrush(Color.FromArgb(0xE6, 0xD4, 0xC5, 0xE0));
             }
         }
         private void ShowColorPicker()
         {
-            var colorPickerWindow = new Window
+            Window colorPickerWindow = new Window
             {
                 Title = "Title Bar Color",
                 Width = 390,
@@ -1992,7 +2195,7 @@ namespace YASN
                 WindowStyle = WindowStyle.ToolWindow
             };
 
-            var stackPanel = new StackPanel { Margin = new Thickness(18) };
+            StackPanel stackPanel = new StackPanel { Margin = new Thickness(18) };
             stackPanel.Children.Add(new TextBlock
             {
                 Text = "Choose a preset color",
@@ -2000,13 +2203,13 @@ namespace YASN
                 Margin = new Thickness(0, 0, 0, 10)
             });
 
-            var colorsGrid = new Grid { Margin = new Thickness(0, 0, 0, 18) };
+            Grid colorsGrid = new Grid { Margin = new Thickness(0, 0, 0, 18) };
             colorsGrid.ColumnDefinitions.Add(new ColumnDefinition());
             colorsGrid.ColumnDefinitions.Add(new ColumnDefinition());
             colorsGrid.ColumnDefinitions.Add(new ColumnDefinition());
 
-            var presetColors = new[]
-            {
+            (string, string)[] presetColors =
+            [
                 ("#E6D4C5E0", "Lavender"),
                 ("#E6FFB6C1", "Rose"),
                 ("#E6B0E0E6", "Sky"),
@@ -2015,10 +2218,10 @@ namespace YASN
                 ("#E6F5DEB3", "Sand"),
                 ("#E6E6E6FA", "Soft Indigo"),
                 ("#E6FFE4E1", "Mist")
-            };
+            ];
 
-            var row = 0;
-            var col = 0;
+            int row = 0;
+            int col = 0;
             foreach (var (colorHex, colorName) in presetColors)
             {
                 if (col == 0)
@@ -2026,7 +2229,7 @@ namespace YASN
                     colorsGrid.RowDefinitions.Add(new RowDefinition());
                 }
 
-                var button = new Button
+                Button button = new Button
                 {
                     Width = 108,
                     Height = 56,
@@ -2038,7 +2241,7 @@ namespace YASN
 
                 button.Click += (s, _) =>
                 {
-                    var selectedColor = (s as Button)?.Tag as string;
+                    string? selectedColor = (s as Button)?.Tag as string;
                     if (!string.IsNullOrEmpty(selectedColor))
                     {
                         NoteData.TitleBarColor = selectedColor;
@@ -2067,12 +2270,12 @@ namespace YASN
 
         private void ShowBackgroundImageMenu(Button anchorButton)
         {
-            var contextMenu = new ContextMenu();
+            ContextMenu contextMenu = new ContextMenu();
 
-            var selectImageItem = new MenuItem { Header = "Select Background Image" };
+            MenuItem selectImageItem = new MenuItem { Header = "Select Background Image" };
             selectImageItem.Click += (_, _) =>
             {
-                var openFileDialog = new OpenFileDialog
+                OpenFileDialog openFileDialog = new OpenFileDialog
                 {
                     Filter = "Image File|*.png;*.jpg;*.jpeg;*.gif;*.bmp;*.webp",
                     Title = "Select Background Image"
@@ -2084,10 +2287,10 @@ namespace YASN
                 }
             };
 
-            var clearBackgroundItem = new MenuItem { Header = "Clear Background Image" };
+            MenuItem clearBackgroundItem = new MenuItem { Header = "Clear Background Image" };
             clearBackgroundItem.Click += (_, _) => ClearBackgroundImage();
 
-            var adjustOpacityItem = new MenuItem { Header = "Adjust Background Opacity" };
+            MenuItem adjustOpacityItem = new MenuItem { Header = "Adjust Background Opacity" };
             adjustOpacityItem.Click += (_, _) => ShowOpacityAdjuster();
 
             contextMenu.Items.Add(selectImageItem);
@@ -2104,7 +2307,7 @@ namespace YASN
             string destPath = null;
             try
             {
-                var fileName = $"background{Path.GetExtension(sourceFilePath)}";
+                string fileName = $"background{Path.GetExtension(sourceFilePath)}";
                 destPath = Path.Combine(_backgroundImageDirectory, fileName);
 
                 if (File.Exists(destPath))
@@ -2118,19 +2321,24 @@ namespace YASN
                 ApplyBackgroundImage(destPath);
                 NoteManager.Instance.UpdateNote(NoteData);
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
-                if (destPath != null && File.Exists(destPath))
-                {
-                    try
-                    {
-                        File.Delete(destPath);
-                    }
-                    catch
-                    {
-                    }
-                }
-
+                TryDeleteGeneratedFile(destPath, "setting background image");
+                AppLogger.Warn($"Failed to set background image from '{sourceFilePath}': {ex.Message}");
+                MessageBox.Show($"Fail to set background image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "setting background image");
+                AppLogger.Warn($"Failed to set background image from '{sourceFilePath}': {ex.Message}");
+                MessageBox.Show($"Fail to set background image: {ex.Message}", "Error",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (ArgumentException ex)
+            {
+                TryDeleteGeneratedFile(destPath, "setting background image");
+                AppLogger.Warn($"Failed to set background image from '{sourceFilePath}': {ex.Message}");
                 MessageBox.Show($"Fail to set background image: {ex.Message}", "Error",
                     MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -2146,7 +2354,7 @@ namespace YASN
 
             try
             {
-                var bitmap = new BitmapImage();
+                BitmapImage bitmap = new BitmapImage();
                 bitmap.BeginInit();
                 bitmap.UriSource = new Uri(imagePath, UriKind.Absolute);
                 bitmap.CacheOption = BitmapCacheOption.OnLoad;
@@ -2154,8 +2362,19 @@ namespace YASN
 
                 BackgroundImageBrush.ImageSource = bitmap;
             }
-            catch
+            catch (IOException ex)
             {
+                AppLogger.Debug($"Failed to load background image '{imagePath}': {ex.Message}");
+                BackgroundImageBrush.ImageSource = null;
+            }
+            catch (NotSupportedException ex)
+            {
+                AppLogger.Debug($"Failed to load background image '{imagePath}': {ex.Message}");
+                BackgroundImageBrush.ImageSource = null;
+            }
+            catch (UriFormatException ex)
+            {
+                AppLogger.Debug($"Failed to load background image '{imagePath}': {ex.Message}");
                 BackgroundImageBrush.ImageSource = null;
             }
         }
@@ -2173,20 +2392,24 @@ namespace YASN
 
             try
             {
-                foreach (var file in Directory.GetFiles(_backgroundImageDirectory))
+                foreach (string file in Directory.GetFiles(_backgroundImageDirectory))
                 {
-                        File.Delete(file);
+                    File.Delete(file);
                 }
             }
-            catch (Exception ex) 
+            catch (IOException ex)
             {
-                AppLogger.Debug(ex.Message);
+                AppLogger.Debug($"Failed to clear background image files in '{_backgroundImageDirectory}': {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to clear background image files in '{_backgroundImageDirectory}': {ex.Message}");
             }
         }
 
         private void ShowOpacityAdjuster()
         {
-            var opacityWindow = new Window
+            Window opacityWindow = new Window
             {
                 Title = "Background Opacity",
                 Width = 300,
@@ -2197,7 +2420,7 @@ namespace YASN
                 WindowStyle = WindowStyle.ToolWindow
             };
 
-            var stackPanel = new StackPanel { Margin = new Thickness(20) };
+            StackPanel stackPanel = new StackPanel { Margin = new Thickness(20) };
             stackPanel.Children.Add(new TextBlock
             {
                 Text = "Background opacity",
@@ -2205,7 +2428,7 @@ namespace YASN
                 Margin = new Thickness(0, 0, 0, 10)
             });
 
-            var slider = new Slider
+            Slider slider = new Slider
             {
                 Minimum = 0.05,
                 Maximum = 1.0,
@@ -2215,7 +2438,7 @@ namespace YASN
                 Margin = new Thickness(0, 0, 0, 10)
             };
 
-            var valueText = new TextBlock
+            TextBlock valueText = new TextBlock
             {
                 Text = $"Current: {BackgroundImageBorder.Opacity:F2}",
                 HorizontalAlignment = HorizontalAlignment.Center,
@@ -2240,7 +2463,7 @@ namespace YASN
 
         private async void RefreshPreview_Click(object sender, RoutedEventArgs e)
         {
-            await RenderPreviewAsync();
+            await RenderPreviewAsync().ConfigureAwait(false);
         }
 
         // For Editor mode switching in title bar
@@ -2255,10 +2478,10 @@ namespace YASN
         }
         private void EditorModeButton_Click(object sender, RoutedEventArgs e)
         {
-            var nextMode = GetNextEditorDisplayMode(_editorDisplayMode);
+            EditorDisplayMode nextMode = GetNextEditorDisplayMode(_editorDisplayMode);
             SetDisplayMode(nextMode, focusEditor: nextMode != EditorDisplayMode.PreviewOnly);
         }
-        
+
         private static string GetEditorModeLabel(EditorDisplayMode mode)
         {
             return mode switch
@@ -2268,16 +2491,16 @@ namespace YASN
                 _ => "Preview only"
             };
         }
-        
+
         private void UpdateEditorModeButton()
         {
-            // for collapse 
+            // for collapse
             if (EditorModeButton == null)
             {
                 return;
             }
 
-            var nextMode = GetNextEditorDisplayMode(_editorDisplayMode);
+            EditorDisplayMode nextMode = GetNextEditorDisplayMode(_editorDisplayMode);
             switch (_editorDisplayMode)
             {
                 case EditorDisplayMode.TextOnly:

--- a/FloatingWindow.xaml.cs
+++ b/FloatingWindow.xaml.cs
@@ -17,6 +17,7 @@ using Markdig;
 using Microsoft.Web.WebView2.Core;
 using YASN.Logging;
 using YASN.Settings;
+using YASN.WindowLayout;
 using Application = System.Windows.Application;
 using Brushes = System.Windows.Media.Brushes;
 using Button = System.Windows.Controls.Button;
@@ -187,7 +188,7 @@ namespace YASN
             _previewDebounceTimer.Tick += async (_, _) =>
             {
                 _previewDebounceTimer.Stop();
-                await RenderPreviewAsync().ConfigureAwait(false);
+                await RenderPreviewAsync();
             };
 
             RefreshChromeBehaviorFromSettings();
@@ -675,7 +676,7 @@ namespace YASN
             try
             {
                 PreviewWebView.DefaultBackgroundColor = DrawingColor.Transparent;
-                await PreviewWebView.EnsureCoreWebView2Async().ConfigureAwait(false);
+                await PreviewWebView.EnsureCoreWebView2Async();
                 PreviewWebView.CoreWebView2.Settings.IsStatusBarEnabled = false;
                 PreviewWebView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
 #if DEBUG
@@ -683,7 +684,7 @@ namespace YASN
 #else
                 PreviewWebView.CoreWebView2.Settings.AreDevToolsEnabled = false;
 #endif
-                await PreviewWebView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(PreviewRightClickBridgeScript).ConfigureAwait(false);
+                await PreviewWebView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(PreviewRightClickBridgeScript);
                 PreviewWebView.CoreWebView2.ContextMenuRequested += PreviewCoreWebView2_ContextMenuRequested;
                 PreviewWebView.CoreWebView2.NavigationStarting += PreviewCoreWebView2_NavigationStarting;
                 PreviewWebView.CoreWebView2.WebMessageReceived += PreviewCoreWebView2_WebMessageReceived;
@@ -695,7 +696,7 @@ namespace YASN
 
                 _previewReady = true;
                 ApplyPreviewClip();
-                await RenderPreviewAsync().ConfigureAwait(false);
+                await RenderPreviewAsync();
             }
             catch (COMException ex)
             {
@@ -728,7 +729,7 @@ namespace YASN
                                              ContentTextBox.IsKeyboardFocusWithin;
                 double scrollRatio = shouldTrackEditorCaret
                     ? GetEditorCaretScrollRatio()
-                    : await CapturePreviewScrollRatioAsync().ConfigureAwait(false);
+                    : await CapturePreviewScrollRatioAsync();
                 _hasPendingPreviewScrollRestore = scrollRatio >= 0;
                 _pendingPreviewScrollRatio = scrollRatio;
 
@@ -740,7 +741,7 @@ namespace YASN
 
                 if (_isPreviewDocumentReady)
                 {
-                    await UpdatePreviewDocumentAsync(htmlBody, NoteData.IsDarkMode, styleHref, scrollRatio).ConfigureAwait(false);
+                    await UpdatePreviewDocumentAsync(htmlBody, NoteData.IsDarkMode, styleHref, scrollRatio);
                     _hasPendingPreviewScrollRestore = false;
                     return;
                 }
@@ -778,7 +779,7 @@ namespace YASN
                 AppLogger.Warn($"Failed to render markdown preview: {ex.Message}");
             }
 
-            await Task.CompletedTask.ConfigureAwait(false);
+            await Task.CompletedTask;
         }
 
         private async Task UpdatePreviewDocumentAsync(string htmlBody, bool darkMode, string styleHref, double scrollRatio)
@@ -795,7 +796,7 @@ namespace YASN
             string ratioLiteral = scrollRatio.ToString("0.########", CultureInfo.InvariantCulture);
 
             string script = $"(() => {{ const html = {htmlJson}; const theme = {themeJson}; const styleHref = {styleJson}; const ratio = {ratioLiteral}; const stickToBottom = ratio >= 0.999; const root = document.scrollingElement || document.documentElement || document.body; const page = document.getElementById('page'); if (!root || !page) return; document.body.className = theme; const style = document.getElementById('yasn-style'); if (style && style.getAttribute('href') !== styleHref) style.setAttribute('href', styleHref); page.innerHTML = html; const apply = () => {{ const max = Math.max(0, root.scrollHeight - root.clientHeight); const target = stickToBottom ? max : Math.max(0, Math.min(1, ratio)) * max; if (typeof root.scrollTo === 'function') {{ root.scrollTo({{ top: target, behavior: stickToBottom ? 'auto' : 'smooth' }}); }} else {{ root.scrollTop = target; }} }}; apply(); requestAnimationFrame(apply); setTimeout(apply, 80); }})();";
-            await PreviewWebView.ExecuteScriptAsync(script).ConfigureAwait(false);
+            await PreviewWebView.ExecuteScriptAsync(script);
         }
 
         private double GetEditorCaretScrollRatio()
@@ -848,7 +849,7 @@ namespace YASN
             try
             {
                 string script = "(() => { const root = document.scrollingElement || document.documentElement || document.body; if (!root) return -1; const max = Math.max(0, root.scrollHeight - root.clientHeight); if (max <= 0) return 0; const top = root.scrollTop || window.scrollY || 0; return top / max; })();";
-                string raw = await PreviewWebView.ExecuteScriptAsync(script).ConfigureAwait(false);
+                string raw = await PreviewWebView.ExecuteScriptAsync(script);
                 if (!double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out double ratio))
                 {
                     return -1;
@@ -897,7 +898,7 @@ namespace YASN
             {
                 string ratioLiteral = _pendingPreviewScrollRatio.ToString("0.########", CultureInfo.InvariantCulture);
                 string script = $"(() => {{ const ratio = {ratioLiteral}; const stickToBottom = ratio >= 0.999; const root = document.scrollingElement || document.documentElement || document.body; if (!root) return; const apply = () => {{ const max = Math.max(0, root.scrollHeight - root.clientHeight); const target = stickToBottom ? max : max * Math.max(0, Math.min(1, ratio)); if (typeof root.scrollTo === 'function') {{ root.scrollTo({{ top: target, behavior: stickToBottom ? 'auto' : 'smooth' }}); }} else {{ root.scrollTop = target; }} }}; apply(); requestAnimationFrame(apply); setTimeout(apply, 80); }})();";
-                await PreviewWebView.ExecuteScriptAsync(script).ConfigureAwait(false);
+                await PreviewWebView.ExecuteScriptAsync(script);
             }
             catch (COMException ex)
             {
@@ -1367,7 +1368,7 @@ namespace YASN
             _hwnd = new WindowInteropHelper(this).Handle;
             RefreshTaskbarVisibilityFromSettings();
             ApplyWindowLevel();
-            await InitializePreviewAsync().ConfigureAwait(false);
+            await InitializePreviewAsync();
             SchedulePreviewRender();
             UpdateChromeBarsByMouseState();
         }
@@ -1618,6 +1619,17 @@ namespace YASN
             }
         }
 
+        private void TitleBar_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (sender is not FrameworkElement placementTarget)
+            {
+                return;
+            }
+
+            ShowTitleBarContextMenu(placementTarget);
+            e.Handled = true;
+        }
+
         private void MinimizeButton_Click(object sender, RoutedEventArgs e)
         {
             if (NoteData.Level != WindowLevel.Normal)
@@ -1632,15 +1644,26 @@ namespace YASN
 
         private void MoreOptions_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is not Button button)
+            if (sender is not FrameworkElement placementTarget)
             {
                 return;
             }
 
+            ShowTitleBarContextMenu(placementTarget);
+        }
+
+        private void ShowTitleBarContextMenu(FrameworkElement placementTarget)
+        {
             ContextMenu contextMenu = new ContextMenu();
 
             MenuItem renameTitleItem = new MenuItem { Header = "Edit Title" };
             renameTitleItem.Click += (_, _) => PromptRenameTitle();
+
+            MenuItem quickMoveItem = new MenuItem { Header = "Quick Move" };
+            quickMoveItem.Click += (_, _) => FloatingWindowQuickActions.ShowQuickMove(this);
+
+            MenuItem quickMoveAndResizeItem = new MenuItem { Header = "Quick Move + Resize" };
+            quickMoveAndResizeItem.Click += (_, _) => FloatingWindowQuickActions.ShowQuickMoveAndResize(this);
 
             MenuItem showMainWindowItem = new MenuItem { Header = "Open MainWindow" };
             showMainWindowItem.Click += (_, _) =>
@@ -1698,7 +1721,7 @@ namespace YASN
             changeTitleBarColorItem.Click += (_, _) => ShowColorPicker();
 
             MenuItem backgroundImageItem = new MenuItem { Header = "Background Image" };
-            backgroundImageItem.Click += (_, _) => ShowBackgroundImageMenu(button);
+            backgroundImageItem.Click += (_, _) => ShowBackgroundImageMenu(placementTarget);
 
             MenuItem aboutItem = new MenuItem { Header = "About" };
             aboutItem.Click += (_, _) =>
@@ -1712,6 +1735,9 @@ namespace YASN
 
             contextMenu.Items.Add(renameTitleItem);
             contextMenu.Items.Add(new Separator());
+            contextMenu.Items.Add(quickMoveItem);
+            contextMenu.Items.Add(quickMoveAndResizeItem);
+            contextMenu.Items.Add(new Separator());
             contextMenu.Items.Add(showMainWindowItem);
             contextMenu.Items.Add(createNoteItem);
             contextMenu.Items.Add(createTopMostNoteItem);
@@ -1724,8 +1750,8 @@ namespace YASN
             contextMenu.Items.Add(new Separator());
             contextMenu.Items.Add(aboutItem);
 
-            contextMenu.PlacementTarget = button;
-            contextMenu.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+            contextMenu.PlacementTarget = placementTarget;
+            contextMenu.Placement = System.Windows.Controls.Primitives.PlacementMode.MousePoint;
             contextMenu.IsOpen = true;
         }
 
@@ -1737,6 +1763,11 @@ namespace YASN
         private void ThemeToggle_Click(object sender, RoutedEventArgs e)
         {
             ToggleTheme();
+        }
+
+        private void QuickResizeButton_Click(object sender, RoutedEventArgs e)
+        {
+            FloatingWindowQuickActions.ShowQuickResize(this);
         }
 
         private void SendToBottom_Click(object sender, RoutedEventArgs e)
@@ -2113,7 +2144,7 @@ namespace YASN
             {
                 string themeClass = isDarkMode ? "theme-dark" : "theme-light";
                 string script = $"(() => {{ if (document.body) document.body.className = '{themeClass}'; }})();";
-                await PreviewWebView.ExecuteScriptAsync(script).ConfigureAwait(false);
+                await PreviewWebView.ExecuteScriptAsync(script);
             }
             catch (COMException ex)
             {
@@ -2161,6 +2192,19 @@ namespace YASN
                 MarkdownToolbar.Background = new SolidColorBrush(Color.FromArgb(0x30, 0xE0, 0xE0, 0xE0));
                 ContentTextBox.Foreground = new SolidColorBrush(Color.FromRgb(0x2C, 0x3E, 0x50));
                 ContentTextBox.Background = new SolidColorBrush(Color.FromArgb(0x80, 0xFF, 0xFF, 0xFF));
+            }
+        }
+
+        internal void ReapplyWindowLevelAfterQuickLayout()
+        {
+            switch (NoteData.Level)
+            {
+                case WindowLevel.BottomMost:
+                    ApplyWindowLevel();
+                    break;
+                case WindowLevel.TopMost:
+                    Topmost = true;
+                    break;
             }
         }
 
@@ -2268,7 +2312,7 @@ namespace YASN
             colorPickerWindow.ShowDialog();
         }
 
-        private void ShowBackgroundImageMenu(Button anchorButton)
+        private void ShowBackgroundImageMenu(FrameworkElement anchorElement)
         {
             ContextMenu contextMenu = new ContextMenu();
 
@@ -2297,8 +2341,8 @@ namespace YASN
             contextMenu.Items.Add(clearBackgroundItem);
             contextMenu.Items.Add(adjustOpacityItem);
 
-            contextMenu.PlacementTarget = anchorButton;
-            contextMenu.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+            contextMenu.PlacementTarget = anchorElement;
+            contextMenu.Placement = System.Windows.Controls.Primitives.PlacementMode.MousePoint;
             contextMenu.IsOpen = true;
         }
 
@@ -2463,7 +2507,7 @@ namespace YASN
 
         private async void RefreshPreview_Click(object sender, RoutedEventArgs e)
         {
-            await RenderPreviewAsync().ConfigureAwait(false);
+            await RenderPreviewAsync();
         }
 
         // For Editor mode switching in title bar

--- a/FloatingWindowTaskbarVisibility.cs
+++ b/FloatingWindowTaskbarVisibility.cs
@@ -10,16 +10,16 @@ namespace YASN
     public static class FloatingWindowTaskbarVisibility
     {
         public const string SettingKey = "floatingWindow.taskbarVisibility";
-        public const string AlwaysShowValue = "alwaysshow";
-        public const string AlwaysHideValue = "alwayshide";
-        public const string HideTopMostOnlyValue = "hidetopmostonly";
+        public const string AlwaysShowValue = "ALWAYSSHOW";
+        public const string AlwaysHideValue = "ALWAYSHIDE";
+        public const string HideTopMostOnlyValue = "HIDETOPMOSTONLY";
 
         // Keep old behavior for compatibility: floating windows were hidden from taskbar by default.
         public const string DefaultValue = AlwaysHideValue;
 
         private static FloatingWindowTaskbarVisibilityMode ParseMode(string value)
         {
-            return (value ?? string.Empty).Trim().ToLowerInvariant() switch
+            return (value ?? string.Empty).Trim().ToUpperInvariant() switch
             {
                 AlwaysShowValue => FloatingWindowTaskbarVisibilityMode.AlwaysShow,
                 HideTopMostOnlyValue => FloatingWindowTaskbarVisibilityMode.HideTopMostOnly,

--- a/Logging/AppLogger.cs
+++ b/Logging/AppLogger.cs
@@ -1,4 +1,7 @@
+using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Security;
 using System.Text.Json;
 using Microsoft.Toolkit.Uwp.Notifications;
 
@@ -64,9 +67,21 @@ namespace YASN.Logging
                     ShowToast(level, message);
                 }
             }
-            catch
+            catch (IOException ex)
             {
-                // Avoid throwing from logger
+                ReportInternalFailure("Write", ex);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                ReportInternalFailure("Write", ex);
+            }
+            catch (NotSupportedException ex)
+            {
+                ReportInternalFailure("Write", ex);
+            }
+            catch (SecurityException ex)
+            {
+                ReportInternalFailure("Write", ex);
             }
         }
 
@@ -77,16 +92,24 @@ namespace YASN.Logging
             {
                 Console.WriteLine(line);
             }
-            catch
+            catch (IOException ex)
             {
-                // ignore terminal output failures
+                ReportInternalFailure("WriteToTerminalInDebug", ex);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                ReportInternalFailure("WriteToTerminalInDebug", ex);
+            }
+            catch (SecurityException ex)
+            {
+                ReportInternalFailure("WriteToTerminalInDebug", ex);
             }
 #endif
         }
 
         private static void EnsureDirectory()
         {
-            var dir = Path.GetDirectoryName(LogPath);
+            string? dir = Path.GetDirectoryName(LogPath);
             if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
             {
                 Directory.CreateDirectory(dir);
@@ -99,10 +122,10 @@ namespace YASN.Logging
             {
                 if (File.Exists(LogPath))
                 {
-                    var info = new FileInfo(LogPath);
+                    FileInfo info = new FileInfo(LogPath);
                     if (info.Length >= _maxBytes)
                     {
-                        var bakPath = LogPath + ".bak";
+                        string bakPath = LogPath + ".bak";
                         if (File.Exists(bakPath))
                         {
                             File.Delete(bakPath);
@@ -111,9 +134,21 @@ namespace YASN.Logging
                     }
                 }
             }
-            catch
+            catch (IOException ex)
             {
-                // ignore rotation failures
+                ReportInternalFailure("RotateIfNeeded", ex);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                ReportInternalFailure("RotateIfNeeded", ex);
+            }
+            catch (NotSupportedException ex)
+            {
+                ReportInternalFailure("RotateIfNeeded", ex);
+            }
+            catch (SecurityException ex)
+            {
+                ReportInternalFailure("RotateIfNeeded", ex);
             }
         }
 
@@ -127,9 +162,17 @@ namespace YASN.Logging
                     .AddText(message)
                     .Show(toast => { toast.ExpirationTime = DateTimeOffset.Now.AddSeconds(_toastExpirationSeconds); });
             }
-            catch
+            catch (COMException ex)
             {
-                // Toast failures should not crash the app
+                ReportInternalFailure("ShowToast", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                ReportInternalFailure("ShowToast", ex);
+            }
+            catch (ArgumentException ex)
+            {
+                ReportInternalFailure("ShowToast", ex);
             }
         }
 
@@ -150,25 +193,47 @@ namespace YASN.Logging
             {
                 if (File.Exists(AppPaths.LocalSettingsPath))
                 {
-                    var json = File.ReadAllText(AppPaths.LocalSettingsPath);
+                    string json = File.ReadAllText(AppPaths.LocalSettingsPath);
                     var dict = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
-                    if (dict != null && dict.TryGetValue("log.maxSizeKb", out var value) &&
-                        int.TryParse(value, out var kb) && kb > 0)
+                    if (dict != null && dict.TryGetValue("log.maxSizeKb", out string? value) &&
+                        int.TryParse(value, out int kb) && kb > 0)
                     {
                         SetMaxSizeKb(kb);
                     }
 
-                    if (dict != null && dict.TryGetValue("log.toastExpirationSeconds", out var toastSeconds) &&
-                        int.TryParse(toastSeconds, out var seconds) && seconds > 0)
+                    if (dict != null && dict.TryGetValue("log.toastExpirationSeconds", out string? toastSeconds) &&
+                        int.TryParse(toastSeconds, out int seconds) && seconds > 0)
                     {
                         SetToastExpirationSeconds(seconds);
                     }
                 }
             }
-            catch
+            catch (IOException ex)
             {
-                // ignore
+                ReportInternalFailure("LoadMaxSizeFromLocalSettings", ex);
             }
+            catch (UnauthorizedAccessException ex)
+            {
+                ReportInternalFailure("LoadMaxSizeFromLocalSettings", ex);
+            }
+            catch (JsonException ex)
+            {
+                ReportInternalFailure("LoadMaxSizeFromLocalSettings", ex);
+            }
+            catch (NotSupportedException ex)
+            {
+                ReportInternalFailure("LoadMaxSizeFromLocalSettings", ex);
+            }
+            catch (SecurityException ex)
+            {
+                ReportInternalFailure("LoadMaxSizeFromLocalSettings", ex);
+            }
+        }
+
+        [Conditional("DEBUG")]
+        private static void ReportInternalFailure(string operation, Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"AppLogger.{operation} failed: {ex}");
         }
     }
 }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -84,6 +84,22 @@
                                                           Tag="{Binding}"
                                                           CommandParameter="BottomMost"
                                                           Click="ChangeNoteLevel_Click"/>
+                                                <Separator/>
+                                                <MenuItem Header="Quick Move"
+                                                          Tag="{Binding}"
+                                                          Click="QuickMoveNote_Click"/>
+                                                <MenuItem Header="Quick Move + Resize"
+                                                          Tag="{Binding}"
+                                                          Click="QuickMoveAndResizeNote_Click"/>
+                                                <MenuItem Header="Quick Resize"
+                                                          Tag="{Binding}"
+                                                          Click="QuickResizeNote_Click"/>
+                                                <MenuItem Header="Move To Mouse Monitor"
+                                                          Tag="{Binding}"
+                                                          Click="MoveNoteToMouseMonitor_Click"/>
+                                                <MenuItem Header="Restore Default Size"
+                                                          Tag="{Binding}"
+                                                          Click="RestoreDefaultSizeForNote_Click"/>
                                             </ContextMenu>
                                         </Border.ContextMenu>
                                         <Grid>
@@ -211,6 +227,16 @@
                             Margin="0,0,0,10"
                             Click="Settings_Click"
                             Background="#9B59B6"
+                            Foreground="White"
+                            BorderThickness="0"
+                            FontSize="13"
+                            Cursor="Hand"/>
+
+                    <Button Content="Restore Selected Default Size"
+                            Padding="12,8"
+                            Margin="0,0,0,10"
+                            Click="RestoreSelectedDefaultSize_Click"
+                            Background="#E67E22"
                             Foreground="White"
                             BorderThickness="0"
                             FontSize="13"

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
+using YASN.Logging;
 using MessageBox = ModernWpf.MessageBox;
 
 namespace YASN
@@ -16,7 +16,7 @@ namespace YASN
         public MainWindow()
         {
             InitializeComponent();
-            
+
             // Converters are already defined in MainWindow.xaml, no need to add them here
         }
 
@@ -29,29 +29,29 @@ namespace YASN
         {
             WindowListView.ItemsSource = null;
             WindowListView.ItemsSource = NoteManager.Instance.Notes;
-            
-            NoWindowsText.Visibility = NoteManager.Instance.Notes.Count == 0 
-                ? Visibility.Visible 
+
+            NoWindowsText.Visibility = NoteManager.Instance.Notes.Count == 0
+                ? Visibility.Visible
                 : Visibility.Collapsed;
         }
 
         private void CreateTopWindow_Click(object sender, RoutedEventArgs e)
         {
-            var noteData = NoteManager.Instance.CreateNote(WindowLevel.TopMost);
+            NoteData noteData = NoteManager.Instance.CreateNote(WindowLevel.TopMost);
             OpenNote(noteData);
             RefreshWindowList();
         }
 
         private void CreateBottomWindow_Click(object sender, RoutedEventArgs e)
         {
-            var noteData = NoteManager.Instance.CreateNote(WindowLevel.BottomMost);
+            NoteData noteData = NoteManager.Instance.CreateNote(WindowLevel.BottomMost);
             OpenNote(noteData);
             RefreshWindowList();
         }
 
         private void CreateNormalWindow_Click(object sender, RoutedEventArgs e)
         {
-            var noteData = NoteManager.Instance.CreateNote(WindowLevel.Normal);
+            NoteData noteData = NoteManager.Instance.CreateNote(WindowLevel.Normal);
             OpenNote(noteData);
             RefreshWindowList();
         }
@@ -73,24 +73,20 @@ namespace YASN
 
         private void DeleteNote_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is System.Windows.Controls.Button button && button.Tag is NoteData noteData)
-            {
-                var result = MessageBox.Show(
-                    $"Are you sure you want to delete '{noteData.Title}'?",
-                    "Confirm Delete",
-                    MessageBoxButton.YesNo,
-                    MessageBoxImage.Warning);
+            if (sender is not System.Windows.Controls.Button button || button.Tag is not NoteData noteData) return;
+            MessageBoxResult? result = MessageBox.Show(
+                $"Are you sure you want to delete '{noteData.Title}'?",
+                "Confirm Delete",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Warning);
 
-                if (result == MessageBoxResult.Yes)
-                {
-                    if (noteData.IsOpen && noteData.Window != null)
-                    {
-                        noteData.Window.Close();
-                    }
-                    NoteManager.Instance.DeleteNote(noteData);
-                    RefreshWindowList();
-                }
+            if (result != MessageBoxResult.Yes) return;
+            if (noteData.IsOpen && noteData.Window != null)
+            {
+                noteData.Window.Close();
             }
+            NoteManager.Instance.DeleteNote(noteData);
+            RefreshWindowList();
         }
 
         private void ChangeNoteLevel_Click(object sender, RoutedEventArgs e)
@@ -130,7 +126,7 @@ namespace YASN
         {
             if (!noteData.IsOpen || noteData.Window == null)
             {
-                var window = new FloatingWindow(noteData);
+                FloatingWindow window = new FloatingWindow(noteData);
                 window.Show();
             }
             else
@@ -151,7 +147,7 @@ namespace YASN
 
         private void Settings_Click(object sender, RoutedEventArgs e)
         {
-            var settingsWindow = new SettingsWindow
+            SettingsWindow settingsWindow = new SettingsWindow
             {
                 Owner = this
             };
@@ -162,15 +158,25 @@ namespace YASN
         {
             try
             {
-                var dataDirectory = AppPaths.DataDirectory;
+                string dataDirectory = AppPaths.DataDirectory;
                 Process.Start(new ProcessStartInfo
                 {
                     FileName = dataDirectory,
                     UseShellExecute = true
                 });
             }
-            catch (Exception ex)
+            catch (InvalidOperationException ex)
             {
+                AppLogger.Warn($"Failed to open data folder '{AppPaths.DataDirectory}': {ex.Message}");
+                MessageBox.Show(
+                    $"Failed to open data folder: {ex.Message}",
+                    "Open Folder Failed",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+            catch (System.ComponentModel.Win32Exception ex)
+            {
+                AppLogger.Warn($"Failed to open data folder '{AppPaths.DataDirectory}': {ex.Message}");
                 MessageBox.Show(
                     $"Failed to open data folder: {ex.Message}",
                     "Open Folder Failed",

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
 using YASN.Logging;
+using YASN.WindowLayout;
 using MessageBox = ModernWpf.MessageBox;
 
 namespace YASN
@@ -133,6 +134,94 @@ namespace YASN
             {
                 noteData.Window.Activate();
             }
+        }
+
+        private FloatingWindow EnsureNoteWindow(NoteData noteData)
+        {
+            OpenNote(noteData);
+            return noteData.Window!;
+        }
+
+        private static void RestoreDefaultSize(NoteData noteData)
+        {
+            if (noteData == null)
+            {
+                return;
+            }
+
+            noteData.Width = NoteManager.DefaultNoteWidth;
+            noteData.Height = NoteManager.DefaultNoteHeight;
+            NoteManager.Instance.UpdateNote(noteData);
+
+            if (noteData.Window != null)
+            {
+                FloatingWindowQuickActions.RestoreDefaultSize(noteData.Window);
+            }
+        }
+
+        private void QuickMoveNote_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not System.Windows.Controls.MenuItem menuItem || menuItem.Tag is not NoteData noteData)
+            {
+                return;
+            }
+
+            FloatingWindowQuickActions.ShowQuickMove(EnsureNoteWindow(noteData));
+        }
+
+        private void QuickMoveAndResizeNote_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not System.Windows.Controls.MenuItem menuItem || menuItem.Tag is not NoteData noteData)
+            {
+                return;
+            }
+
+            FloatingWindowQuickActions.ShowQuickMoveAndResize(EnsureNoteWindow(noteData));
+        }
+
+        private void QuickResizeNote_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not System.Windows.Controls.MenuItem menuItem || menuItem.Tag is not NoteData noteData)
+            {
+                return;
+            }
+
+            FloatingWindowQuickActions.ShowQuickResize(EnsureNoteWindow(noteData));
+        }
+
+        private void MoveNoteToMouseMonitor_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not System.Windows.Controls.MenuItem menuItem || menuItem.Tag is not NoteData noteData)
+            {
+                return;
+            }
+
+            FloatingWindowQuickActions.MoveToMouseMonitor(EnsureNoteWindow(noteData));
+        }
+
+        private void RestoreDefaultSizeForNote_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not System.Windows.Controls.MenuItem menuItem || menuItem.Tag is not NoteData noteData)
+            {
+                return;
+            }
+
+            RestoreDefaultSize(noteData);
+        }
+
+        private void RestoreSelectedDefaultSize_Click(object sender, RoutedEventArgs e)
+        {
+            if (WindowListView.SelectedItem is not NoteData noteData)
+            {
+                MessageBox.Show(
+                    "Select a note first.",
+                    "Restore Default Size",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+                return;
+            }
+
+            RestoreDefaultSize(noteData);
         }
 
         private void HideToTray_Click(object sender, RoutedEventArgs e)

--- a/Markdown/Extensions/MarkdigHexColorExtension.cs
+++ b/Markdown/Extensions/MarkdigHexColorExtension.cs
@@ -76,36 +76,36 @@ namespace YASN.Markdown.Extensions
 
         public override bool Match(InlineProcessor processor, ref StringSlice slice)
         {
-            var text = slice.Text;
-            var start = slice.Start;
-            var end = slice.End;
+            string text = slice.Text;
+            int start = slice.Start;
+            int end = slice.End;
 
             if (start + 5 > end || text[start] != '{' || text[start + 1] != '#')
             {
                 return false;
             }
 
-            var i = start + 2;
-            var colorTokenStart = i;
+            int i = start + 2;
+            int colorTokenStart = i;
             while (i <= end && text[i] != '|')
             {
                 i++;
             }
 
-            var colorTokenLength = i - colorTokenStart;
+            int colorTokenLength = i - colorTokenStart;
             if (i > end || text[i] != '|' || colorTokenLength <= 0)
             {
                 return false;
             }
 
-            var colorToken = text.Substring(colorTokenStart, colorTokenLength);
-            if (!TryResolveColorHex(colorToken, out var colorHex))
+            string colorToken = text.Substring(colorTokenStart, colorTokenLength);
+            if (!TryResolveColorHex(colorToken, out string? colorHex))
             {
                 return false;
             }
 
             i++;
-            var contentStart = i;
+            int contentStart = i;
             while (i <= end && text[i] != '}')
             {
                 i++;
@@ -116,8 +116,8 @@ namespace YASN.Markdown.Extensions
                 return false;
             }
 
-            var content = text.Substring(contentStart, i - contentStart);
-            var inline = new HexColorInline(colorHex, content)
+            string content = text.Substring(contentStart, i - contentStart);
+            HexColorInline inline = new HexColorInline(colorHex, content)
             {
                 Span = new SourceSpan(start, i)
             };
@@ -140,7 +140,7 @@ namespace YASN.Markdown.Extensions
                 return true;
             }
 
-            if (ColorAliases.TryGetValue(token, out var aliasedHex))
+            if (ColorAliases.TryGetValue(token, out string? aliasedHex))
             {
                 colorHex = aliasedHex;
                 return true;
@@ -157,7 +157,7 @@ namespace YASN.Markdown.Extensions
 
         protected override void Write(HtmlRenderer renderer, HexColorInline obj)
         {
-            var inlineHtml = StripParagraphWrapper(global::Markdig.Markdown.ToHtml(obj.MarkdownText, InlinePipeline));
+            string inlineHtml = StripParagraphWrapper(global::Markdig.Markdown.ToHtml(obj.MarkdownText, InlinePipeline));
 
             renderer
                 .Write("<span style=\"color:")
@@ -169,7 +169,7 @@ namespace YASN.Markdown.Extensions
 
         private static string StripParagraphWrapper(string html)
         {
-            var trimmed = html.Trim();
+            string trimmed = html.Trim();
             if (trimmed.StartsWith("<p>", StringComparison.Ordinal) &&
                 trimmed.EndsWith("</p>", StringComparison.Ordinal))
             {

--- a/NoteData.cs
+++ b/NoteData.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel;
 
 namespace YASN

--- a/NoteManager.cs
+++ b/NoteManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -11,7 +12,7 @@ namespace YASN
     public class NoteManager
     {
         private static NoteManager _instance;
-        private static readonly object _lock = new object();
+        private static readonly Lock _lock = new Lock();
 
         private const string LegacySaveFileName = "notes.json";
         private const int CurrentSchemaVersion = 2;
@@ -44,7 +45,7 @@ namespace YASN
 
         public NoteData CreateNote(WindowLevel level = WindowLevel.Normal)
         {
-            var note = new NoteData
+            NoteData note = new NoteData
             {
                 Id = _nextId++,
                 Title = $"Note #{_nextId - 1}",
@@ -80,21 +81,21 @@ namespace YASN
             Notes.Remove(note);
             TryDeleteFile(AppPaths.GetNoteMarkdownPath(note.Id));
             TryDeleteFile(AppPaths.GetNoteHtmlCachePath(note.Id));
-            TryDeleteDirectory(Path.Combine(AppPaths.NoteAssetsRoot, note.Id.ToString()));
-            TryDeleteDirectory(Path.Combine(AppPaths.NoteBackgroundsRoot, note.Id.ToString()));
+            TryDeleteDirectory(Path.Combine(AppPaths.NoteAssetsRoot, note.Id.ToString(CultureInfo.InvariantCulture)));
+            TryDeleteDirectory(Path.Combine(AppPaths.NoteBackgroundsRoot, note.Id.ToString(CultureInfo.InvariantCulture)));
             Save();
         }
 
-        public void Save()
+        private void Save()
         {
             try
             {
-                var options = new JsonSerializerOptions
+                JsonSerializerOptions options = new JsonSerializerOptions
                 {
                     WriteIndented = true
                 };
 
-                var index = new NoteIndexDto
+                NoteIndexDto index = new NoteIndexDto
                 {
                     SchemaVersion = CurrentSchemaVersion,
                     UpdatedAtUtc = DateTime.UtcNow,
@@ -120,14 +121,26 @@ namespace YASN
 
                 WriteTextFile(IndexFilePath, JsonSerializer.Serialize(index, options));
 
-                foreach (var note in Notes)
+                foreach (NoteData note in Notes)
                 {
                     WriteTextFile(AppPaths.GetNoteMarkdownPath(note.Id), note.Content ?? string.Empty);
                 }
 
                 // AppLogger.Debug($"Saved {Notes.Count} notes to {IndexFilePath} (schema v{CurrentSchemaVersion})");
             }
-            catch (Exception ex)
+            catch (IOException ex)
+            {
+                AppLogger.Warn($"Failed to save notes: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Warn($"Failed to save notes: {ex.Message}");
+            }
+            catch (JsonException ex)
+            {
+                AppLogger.Warn($"Failed to save notes: {ex.Message}");
+            }
+            catch (NotSupportedException ex)
             {
                 AppLogger.Warn($"Failed to save notes: {ex.Message}");
             }
@@ -151,24 +164,24 @@ namespace YASN
                     return;
                 }
 
-                var json = File.ReadAllText(IndexFilePath);
+                string json = File.ReadAllText(IndexFilePath);
                 var (items, schemaVersion) = ParseIndexItems(json);
-                if (items == null)
+                if (items.Length == 0 && schemaVersion == 0)
                 {
                     return;
                 }
 
-                var shouldRewrite = schemaVersion < CurrentSchemaVersion;
-                foreach (var item in items)
+                bool shouldRewrite = schemaVersion < CurrentSchemaVersion;
+                foreach (NoteMetadataDto item in items)
                 {
-                    var content = ReadMarkdownContent(item.Id);
+                    string content = ReadMarkdownContent(item.Id);
                     if (string.IsNullOrEmpty(content) && !string.IsNullOrEmpty(item.Content))
                     {
                         content = NormalizeLegacyContent(item.Content);
                         shouldRewrite = true;
                     }
 
-                    var note = new NoteData
+                    NoteData note = new NoteData
                     {
                         Id = item.Id,
                         Title = item.Title ?? $"Note #{item.Id}",
@@ -202,23 +215,39 @@ namespace YASN
 
                 AppLogger.Debug($"Loaded {Notes.Count} notes from {IndexFilePath}");
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
-                AppLogger.Debug($"Failed to load notes: {ex.Message}\nStack trace: {ex.StackTrace}");
+                AppLogger.Debug($"Failed to load notes: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to load notes: {ex.Message}");
+            }
+            catch (JsonException ex)
+            {
+                AppLogger.Debug($"Failed to load notes: {ex.Message}");
+            }
+            catch (NotSupportedException ex)
+            {
+                AppLogger.Debug($"Failed to load notes: {ex.Message}");
             }
         }
 
         public void RestoreOpenNotes()
         {
-            var openNotes = Notes.Where(n => n.IsOpen).ToList();
-            foreach (var note in openNotes)
+            List<NoteData> openNotes = Notes.Where(n => n.IsOpen).ToList();
+            foreach (NoteData note in openNotes)
             {
                 try
                 {
-                    var window = new FloatingWindow(note);
+                    FloatingWindow window = new FloatingWindow(note);
                     window.Show();
                 }
-                catch (Exception ex)
+                catch (InvalidOperationException ex)
+                {
+                    AppLogger.Debug($"Failed to restore note window {note.Id}: {ex.Message}");
+                }
+                catch (Win32Exception ex)
                 {
                     AppLogger.Debug($"Failed to restore note window {note.Id}: {ex.Message}");
                 }
@@ -227,7 +256,7 @@ namespace YASN
 
         public void ReloadNotes()
         {
-            foreach (var note in Notes.Where(n => n.IsOpen).ToList())
+            foreach (NoteData note in Notes.Where(n => n.IsOpen).ToList())
             {
                 note.Window?.Close();
             }
@@ -239,13 +268,13 @@ namespace YASN
 
         private void TryMigrateLegacyStorage()
         {
-            var legacyCandidates = new[]
+            string[] legacyCandidates = new[]
             {
                 AppPaths.LegacyNotesFilePath,
                 Path.Combine(AppDomain.CurrentDomain.BaseDirectory, LegacySaveFileName)
             };
 
-            var legacyPath = legacyCandidates.FirstOrDefault(File.Exists);
+            string? legacyPath = legacyCandidates.FirstOrDefault(File.Exists);
             if (string.IsNullOrEmpty(legacyPath))
             {
                 return;
@@ -253,21 +282,21 @@ namespace YASN
 
             try
             {
-                var legacyJson = File.ReadAllText(legacyPath);
-                var legacyItems = JsonSerializer.Deserialize<LegacyNoteDataDto[]>(legacyJson);
+                string legacyJson = File.ReadAllText(legacyPath);
+                LegacyNoteDataDto[]? legacyItems = JsonSerializer.Deserialize<LegacyNoteDataDto[]>(legacyJson);
                 if (legacyItems == null || legacyItems.Length == 0)
                 {
                     return;
                 }
 
-                var backupPath = Path.Combine(AppPaths.DataDirectory, "notes.v1.backup.json");
+                string backupPath = Path.Combine(AppPaths.DataDirectory, "notes.v1.backup.json");
                 if (!File.Exists(backupPath))
                 {
                     WriteTextFile(backupPath, legacyJson);
                 }
 
                 Notes.Clear();
-                foreach (var item in legacyItems)
+                foreach (LegacyNoteDataDto item in legacyItems)
                 {
                     Notes.Add(new NoteData
                     {
@@ -292,7 +321,19 @@ namespace YASN
                 Save();
                 AppLogger.Debug($"Migrated {Notes.Count} legacy notes from {legacyPath}");
             }
-            catch (Exception ex)
+            catch (IOException ex)
+            {
+                AppLogger.Debug($"Failed to migrate legacy notes: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to migrate legacy notes: {ex.Message}");
+            }
+            catch (JsonException ex)
+            {
+                AppLogger.Debug($"Failed to migrate legacy notes: {ex.Message}");
+            }
+            catch (NotSupportedException ex)
             {
                 AppLogger.Debug($"Failed to migrate legacy notes: {ex.Message}");
             }
@@ -302,24 +343,35 @@ namespace YASN
         {
             try
             {
-                using var doc = JsonDocument.Parse(json);
+                using JsonDocument doc = JsonDocument.Parse(json);
                 if (doc.RootElement.ValueKind == JsonValueKind.Array)
                 {
                     var notes = JsonSerializer.Deserialize<NoteMetadataDto[]>(json);
-                    return (notes, 1);
+                    return (notes ?? Array.Empty<NoteMetadataDto>(), 1);
                 }
 
                 if (doc.RootElement.ValueKind != JsonValueKind.Object)
                 {
-                    return (null, 0);
+                    return (Array.Empty<NoteMetadataDto>(), 0);
                 }
 
-                var index = JsonSerializer.Deserialize<NoteIndexDto>(json);
+                NoteIndexDto? index = JsonSerializer.Deserialize<NoteIndexDto>(json);
                 return (index?.Notes ?? Array.Empty<NoteMetadataDto>(), index?.SchemaVersion ?? 1);
             }
-            catch
+            catch (JsonException ex)
             {
-                return (null, 0);
+                AppLogger.Debug($"Failed to parse notes index: {ex.Message}");
+                return (Array.Empty<NoteMetadataDto>(), 0);
+            }
+            catch (NotSupportedException ex)
+            {
+                AppLogger.Debug($"Failed to parse notes index: {ex.Message}");
+                return (Array.Empty<NoteMetadataDto>(), 0);
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Debug($"Failed to parse notes index: {ex.Message}");
+                return (Array.Empty<NoteMetadataDto>(), 0);
             }
         }
 
@@ -327,11 +379,17 @@ namespace YASN
         {
             try
             {
-                var path = AppPaths.GetNoteMarkdownPath(noteId);
+                string path = AppPaths.GetNoteMarkdownPath(noteId);
                 return File.Exists(path) ? File.ReadAllText(path) : string.Empty;
             }
-            catch
+            catch (IOException ex)
             {
+                AppLogger.Debug($"Failed to read note content for note {noteId}: {ex.Message}");
+                return string.Empty;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to read note content for note {noteId}: {ex.Message}");
                 return string.Empty;
             }
         }
@@ -352,13 +410,13 @@ namespace YASN
         {
             try
             {
-                var sb = new StringBuilder();
-                var skipStack = new Stack<bool>();
-                var skipDestination = false;
-                var ucSkipCount = 1;
-                var pendingSkip = 0;
+                StringBuilder sb = new StringBuilder();
+                Stack<bool> skipStack = new Stack<bool>();
+                bool skipDestination = false;
+                int ucSkipCount = 1;
+                int pendingSkip = 0;
 
-                for (var i = 0; i < rtf.Length; i++)
+                for (int i = 0; i < rtf.Length; i++)
                 {
                     if (pendingSkip > 0)
                     {
@@ -366,7 +424,7 @@ namespace YASN
                         continue;
                     }
 
-                    var c = rtf[i];
+                    char c = rtf[i];
                     if (c == '{')
                     {
                         skipStack.Push(skipDestination);
@@ -386,7 +444,7 @@ namespace YASN
                             break;
                         }
 
-                        var next = rtf[++i];
+                        char next = rtf[++i];
                         if (next == '\\' || next == '{' || next == '}')
                         {
                             if (!skipDestination)
@@ -407,8 +465,8 @@ namespace YASN
                         {
                             if (i + 2 < rtf.Length)
                             {
-                                var hex = rtf.Substring(i + 1, 2);
-                                if (byte.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var b) && !skipDestination)
+                                string hex = rtf.Substring(i + 1, 2);
+                                if (byte.TryParse(hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out byte b) && !skipDestination)
                                 {
                                     sb.Append((char)b);
                                 }
@@ -436,35 +494,35 @@ namespace YASN
                             continue;
                         }
 
-                        var wordStart = i;
+                        int wordStart = i;
                         while (i < rtf.Length && char.IsLetter(rtf[i]))
                         {
                             i++;
                         }
 
-                        var word = rtf.Substring(wordStart, i - wordStart);
-                        var sign = 1;
+                        string word = rtf.Substring(wordStart, i - wordStart);
+                        int sign = 1;
                         if (i < rtf.Length && (rtf[i] == '-' || rtf[i] == '+'))
                         {
                             sign = rtf[i] == '-' ? -1 : 1;
                             i++;
                         }
 
-                        var numStart = i;
+                        int numStart = i;
                         while (i < rtf.Length && char.IsDigit(rtf[i]))
                         {
                             i++;
                         }
 
-                        var hasParam = i > numStart;
-                        var param = 0;
+                        bool hasParam = i > numStart;
+                        int param = 0;
                         if (hasParam)
                         {
                             int.TryParse(rtf.Substring(numStart, i - numStart), out param);
                             param *= sign;
                         }
 
-                        var hasDelimiterSpace = i < rtf.Length && rtf[i] == ' ';
+                        bool hasDelimiterSpace = i < rtf.Length && rtf[i] == ' ';
                         if (!hasDelimiterSpace)
                         {
                             i--;
@@ -492,7 +550,7 @@ namespace YASN
                             case "u":
                                 if (hasParam)
                                 {
-                                    var codePoint = param;
+                                    int codePoint = param;
                                     if (codePoint < 0)
                                     {
                                         codePoint += 65536;
@@ -518,17 +576,23 @@ namespace YASN
                     }
                 }
 
-                return sb.ToString().Replace("\r\n", "\n").TrimEnd();
+                return sb.ToString().Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd();
             }
-            catch
+            catch (ArgumentOutOfRangeException ex)
             {
+                AppLogger.Debug($"Failed to convert RTF note content: {ex.Message}");
+                return rtf;
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Debug($"Failed to convert RTF note content: {ex.Message}");
                 return rtf;
             }
         }
 
         private static void WriteTextFile(string path, string content)
         {
-            var directory = Path.GetDirectoryName(path);
+            string? directory = Path.GetDirectoryName(path);
             if (!string.IsNullOrEmpty(directory))
             {
                 Directory.CreateDirectory(directory);
@@ -546,9 +610,13 @@ namespace YASN
                     File.Delete(path);
                 }
             }
-            catch
+            catch (IOException ex)
             {
-                // ignored
+                AppLogger.Debug($"Failed to delete file '{path}': {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to delete file '{path}': {ex.Message}");
             }
         }
 
@@ -561,9 +629,13 @@ namespace YASN
                     Directory.Delete(path, true);
                 }
             }
-            catch
+            catch (IOException ex)
             {
-                // ignored
+                AppLogger.Debug($"Failed to delete directory '{path}': {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to delete directory '{path}': {ex.Message}");
             }
         }
 

--- a/NoteManager.cs
+++ b/NoteManager.cs
@@ -16,6 +16,8 @@ namespace YASN
 
         private const string LegacySaveFileName = "notes.json";
         private const int CurrentSchemaVersion = 2;
+        public const double DefaultNoteWidth = 760;
+        public const double DefaultNoteHeight = 460;
 
         private static string IndexFilePath => AppPaths.NotesIndexPath;
 
@@ -53,8 +55,8 @@ namespace YASN
                 Level = level,
                 Left = 100,
                 Top = 100,
-                Width = 760,
-                Height = 460,
+                Width = DefaultNoteWidth,
+                Height = DefaultNoteHeight,
                 IsOpen = false
             };
 

--- a/PreviewStyleManager.cs
+++ b/PreviewStyleManager.cs
@@ -33,7 +33,15 @@ namespace YASN
                     EnsureDefaultStyleExists();
                     _initialized = true;
                 }
-                catch (Exception ex)
+                catch (IOException ex)
+                {
+                    AppLogger.Warn($"Failed to initialize style directory: {ex.Message}");
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    AppLogger.Warn($"Failed to initialize style directory: {ex.Message}");
+                }
+                catch (NotSupportedException ex)
                 {
                     AppLogger.Warn($"Failed to initialize style directory: {ex.Message}");
                 }
@@ -45,7 +53,7 @@ namespace YASN
             EnsureInitialized();
             try
             {
-                var files = Directory.GetFiles(AppPaths.StyleRoot, "*.css", SearchOption.AllDirectories)
+                List<string> files = Directory.GetFiles(AppPaths.StyleRoot, "*.css", SearchOption.AllDirectories)
                     .Select(ToStyleRelativePath)
                     .Where(path => !string.IsNullOrWhiteSpace(path))
                     .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -60,17 +68,27 @@ namespace YASN
                 AppLogger.Debug($"Discovered {files.Count} preview style file(s).");
                 return files;
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 AppLogger.Warn($"Failed to enumerate preview styles: {ex.Message}");
-                return new[] { DefaultStyleRelativePath };
+                return [DefaultStyleRelativePath];
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Warn($"Failed to enumerate preview styles: {ex.Message}");
+                return [DefaultStyleRelativePath];
+            }
+            catch (NotSupportedException ex)
+            {
+                AppLogger.Warn($"Failed to enumerate preview styles: {ex.Message}");
+                return [DefaultStyleRelativePath];
             }
         }
 
         internal static string ResolveStyle(string? configuredStyle)
         {
             EnsureInitialized();
-            if (!TryNormalizeStylePath(configuredStyle, out var normalized))
+            if (!TryNormalizeStylePath(configuredStyle, out string? normalized))
             {
                 if (!string.IsNullOrWhiteSpace(configuredStyle))
                 {
@@ -80,7 +98,7 @@ namespace YASN
                 return DefaultStyleRelativePath;
             }
 
-            var absolutePath = ToStyleAbsolutePath(normalized);
+            string absolutePath = ToStyleAbsolutePath(normalized);
             if (File.Exists(absolutePath))
             {
                 return normalized;
@@ -92,8 +110,8 @@ namespace YASN
 
         internal static string BuildStyleHref(string styleRelativePath, long cacheToken)
         {
-            var resolved = ResolveStyle(styleRelativePath);
-            var encodedPath = string.Join("/",
+            string resolved = ResolveStyle(styleRelativePath);
+            string encodedPath = string.Join("/",
                 resolved.Split('/', StringSplitOptions.RemoveEmptyEntries)
                     .Select(Uri.EscapeDataString));
             return $"style/{encodedPath}?v={cacheToken}";
@@ -102,22 +120,22 @@ namespace YASN
         internal static string ToStyleAbsolutePath(string styleRelativePath)
         {
             EnsureInitialized();
-            var normalized = TryNormalizePathWithoutFallback(styleRelativePath, out var parsed)
+            string normalized = TryNormalizePathWithoutFallback(styleRelativePath, out string? parsed)
                 ? parsed
                 : DefaultStyleRelativePath;
-            var localRelative = normalized.Replace('/', Path.DirectorySeparatorChar);
+            string localRelative = normalized.Replace('/', Path.DirectorySeparatorChar);
             return Path.Combine(AppPaths.StyleRoot, localRelative);
         }
 
         private static void EnsureDefaultStyleExists()
         {
-            var path = Path.Combine(AppPaths.StyleRoot, DefaultStyleRelativePath);
+            string path = Path.Combine(AppPaths.StyleRoot, DefaultStyleRelativePath);
             if (File.Exists(path))
             {
                 return;
             }
 
-            var bundledPath = Path.Combine(BundledStyleRoot, DefaultStyleRelativePath);
+            string bundledPath = Path.Combine(BundledStyleRoot, DefaultStyleRelativePath);
             if (File.Exists(bundledPath))
             {
                 File.Copy(bundledPath, path, overwrite: false);
@@ -134,30 +152,28 @@ namespace YASN
         {
             if (!Directory.Exists(BundledStyleRoot))
             {
-                if (!_missingBundleDirLogged)
-                {
-                    AppLogger.Warn($"Bundled style directory not found: {BundledStyleRoot}");
-                    _missingBundleDirLogged = true;
-                }
+                if (_missingBundleDirLogged) return;
+                AppLogger.Warn($"Bundled style directory not found: {BundledStyleRoot}");
+                _missingBundleDirLogged = true;
 
                 return;
             }
 
-            foreach (var sourcePath in Directory.GetFiles(BundledStyleRoot, "*.css", SearchOption.AllDirectories))
+            foreach (string sourcePath in Directory.GetFiles(BundledStyleRoot, "*.css", SearchOption.AllDirectories))
             {
-                var relative = Path.GetRelativePath(BundledStyleRoot, sourcePath);
-                var destination = Path.Combine(AppPaths.StyleRoot, relative);
-                var destinationDir = Path.GetDirectoryName(destination);
+                string relative = Path.GetRelativePath(BundledStyleRoot, sourcePath);
+                string destination = Path.Combine(AppPaths.StyleRoot, relative);
+                string? destinationDir = Path.GetDirectoryName(destination);
                 if (!string.IsNullOrEmpty(destinationDir))
                 {
                     Directory.CreateDirectory(destinationDir);
                 }
 
-                var shouldCopy = !File.Exists(destination);
+                bool shouldCopy = !File.Exists(destination);
                 if (!shouldCopy)
                 {
-                    var sourceWriteTime = File.GetLastWriteTimeUtc(sourcePath);
-                    var destinationWriteTime = File.GetLastWriteTimeUtc(destination);
+                    DateTime sourceWriteTime = File.GetLastWriteTimeUtc(sourcePath);
+                    DateTime destinationWriteTime = File.GetLastWriteTimeUtc(destination);
                     shouldCopy = sourceWriteTime > destinationWriteTime;
                 }
 
@@ -181,14 +197,14 @@ namespace YASN
 
             try
             {
-                var candidate = raw.Trim();
+                string candidate = raw.Trim();
                 if (Path.IsPathRooted(candidate))
                 {
                     return false;
                 }
 
-                var fullStyleRoot = Path.GetFullPath(AppPaths.StyleRoot);
-                var fullCandidate = Path.GetFullPath(Path.Combine(AppPaths.StyleRoot, candidate));
+                string fullStyleRoot = Path.GetFullPath(AppPaths.StyleRoot);
+                string fullCandidate = Path.GetFullPath(Path.Combine(AppPaths.StyleRoot, candidate));
                 if (!fullCandidate.StartsWith(fullStyleRoot, StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
@@ -199,7 +215,7 @@ namespace YASN
                     return false;
                 }
 
-                var relative = Path.GetRelativePath(fullStyleRoot, fullCandidate)
+                string relative = Path.GetRelativePath(fullStyleRoot, fullCandidate)
                     .Replace('\\', '/')
                     .Trim();
                 if (string.IsNullOrWhiteSpace(relative) ||
@@ -212,8 +228,24 @@ namespace YASN
                 normalized = relative;
                 return true;
             }
-            catch
+            catch (ArgumentException ex)
             {
+                AppLogger.Debug($"Failed to normalize preview style path '{raw}': {ex.Message}");
+                return false;
+            }
+            catch (IOException ex)
+            {
+                AppLogger.Debug($"Failed to normalize preview style path '{raw}': {ex.Message}");
+                return false;
+            }
+            catch (NotSupportedException ex)
+            {
+                AppLogger.Debug($"Failed to normalize preview style path '{raw}': {ex.Message}");
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to normalize preview style path '{raw}': {ex.Message}");
                 return false;
             }
         }
@@ -222,15 +254,31 @@ namespace YASN
         {
             try
             {
-                var relative = Path.GetRelativePath(AppPaths.StyleRoot, fullPath)
+                string relative = Path.GetRelativePath(AppPaths.StyleRoot, fullPath)
                     .Replace('\\', '/')
                     .Trim();
-                return TryNormalizePathWithoutFallback(relative, out var normalized)
+                return TryNormalizePathWithoutFallback(relative, out string? normalized)
                     ? normalized
                     : string.Empty;
             }
-            catch
+            catch (ArgumentException ex)
             {
+                AppLogger.Debug($"Failed to convert style path '{fullPath}' to relative path: {ex.Message}");
+                return string.Empty;
+            }
+            catch (IOException ex)
+            {
+                AppLogger.Debug($"Failed to convert style path '{fullPath}' to relative path: {ex.Message}");
+                return string.Empty;
+            }
+            catch (NotSupportedException ex)
+            {
+                AppLogger.Debug($"Failed to convert style path '{fullPath}' to relative path: {ex.Message}");
+                return string.Empty;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to convert style path '{fullPath}' to relative path: {ex.Message}");
                 return string.Empty;
             }
         }

--- a/Settings/AttachmentSyncSettings.cs
+++ b/Settings/AttachmentSyncSettings.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace YASN.Settings
 {
     internal static class AttachmentSyncSettings
@@ -9,13 +11,13 @@ namespace YASN.Settings
 
         internal static bool GetAutoSyncEnabled(SettingsStore settingsStore)
         {
-            var raw = settingsStore.GetValue(AutoSyncEnabledKey, shouldSync: false, DefaultAutoSyncEnabled.ToString());
-            return !bool.TryParse(raw, out var value) || value;
+            string raw = settingsStore.GetValue(AutoSyncEnabledKey, shouldSync: false, DefaultAutoSyncEnabled.ToString(CultureInfo.InvariantCulture));
+            return !bool.TryParse(raw, out bool value) || value;
         }
 
         private static int GetAutoSyncThresholdMb(SettingsStore settingsStore)
         {
-            var raw = settingsStore.GetValue(AutoSyncThresholdMbKey, shouldSync: false, DefaultAutoSyncThresholdMb.ToString());
+            string raw = settingsStore.GetValue(AutoSyncThresholdMbKey, shouldSync: false, DefaultAutoSyncThresholdMb.ToString(CultureInfo.InvariantCulture));
             return ParseThresholdMb(raw);
         }
 
@@ -28,22 +30,13 @@ namespace YASN.Settings
         {
             const int minMb = 1;
             const int maxMb = 1024;
-            if (int.TryParse(value, out var mb))
+            if (!int.TryParse(value, out int mb)) return DefaultAutoSyncThresholdMb;
+            return mb switch
             {
-                if (mb < minMb)
-                {
-                    return minMb;
-                }
-
-                if (mb > maxMb)
-                {
-                    return maxMb;
-                }
-
-                return mb;
-            }
-
-            return DefaultAutoSyncThresholdMb;
+                < minMb => minMb,
+                > maxMb => maxMb,
+                _ => mb
+            };
         }
     }
 }

--- a/Settings/EditorDisplayModeSettings.cs
+++ b/Settings/EditorDisplayModeSettings.cs
@@ -49,7 +49,7 @@ namespace YASN.Settings
 
         internal static EditorDisplayMode GetEnterMode(SettingsStore settingsStore)
         {
-            var raw = settingsStore.GetValue(
+            string raw = settingsStore.GetValue(
                 SettingKey,
                 shouldSync: false,
                 defaultValue: DefaultValue);

--- a/Settings/EditorSettingsFieldFactory.cs
+++ b/Settings/EditorSettingsFieldFactory.cs
@@ -9,7 +9,7 @@ namespace YASN.Settings
     {
         internal static EditorSettingFields Create()
         {
-            var enterModeField = new SettingField
+            SettingField enterModeField = new SettingField
             {
                 Key = EditorDisplayModeSettings.SettingKey,
                 Title = "Edit Mode",

--- a/Settings/GeneralSettingsFieldFactory.cs
+++ b/Settings/GeneralSettingsFieldFactory.cs
@@ -14,7 +14,7 @@ namespace YASN.Settings
     {
         internal static GeneralSettingFields Create()
         {
-            var autoStartField = new SettingField
+            SettingField autoStartField = new SettingField
             {
                 Key = "autoStart",
                 Title = "Start on Windows startup",
@@ -24,7 +24,7 @@ namespace YASN.Settings
                 ShouldSync = false
             };
 
-            var autoCollapseNoteChromeField = new SettingField
+            SettingField autoCollapseNoteChromeField = new SettingField
             {
                 Key = NoteWindowUiSettings.SettingKey,
                 Title = "Auto collapse note window bar",
@@ -34,7 +34,7 @@ namespace YASN.Settings
                 ShouldSync = false
             };
 
-            var logSizeField = new SettingField
+            SettingField logSizeField = new SettingField
             {
                 Key = "log.maxSizeKb",
                 Title = "Max size of log file",
@@ -44,7 +44,7 @@ namespace YASN.Settings
                 ShouldSync = true
             };
 
-            var floatingTaskbarVisibilityField = new SettingField
+            SettingField floatingTaskbarVisibilityField = new SettingField
             {
                 Key = global::YASN.FloatingWindowTaskbarVisibility.SettingKey,
                 Title = "Show notes in taskbar",
@@ -70,7 +70,7 @@ namespace YASN.Settings
                 Value = global::YASN.FloatingWindowTaskbarVisibility.HideTopMostOnlyValue
             });
 
-            var previewStyleField = new SettingField
+            SettingField previewStyleField = new SettingField
             {
                 Key = global::YASN.PreviewStyleManager.SettingKey,
                 Title = "Markdown preview style",
@@ -85,7 +85,7 @@ namespace YASN.Settings
                 Value = global::YASN.PreviewStyleManager.DefaultStyleRelativePath
             });
 
-            var dataDirectoryField = new SettingField
+            SettingField dataDirectoryField = new SettingField
             {
                 Key = global::YASN.AppPaths.DataDirectorySettingKey,
                 Title = "Data directory",

--- a/Settings/NoteWindowUiSettings.cs
+++ b/Settings/NoteWindowUiSettings.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace YASN.Settings
 {
     internal static class NoteWindowUiSettings
@@ -7,12 +9,12 @@ namespace YASN.Settings
 
         internal static bool IsAutoCollapseChromeEnabled(SettingsStore settingsStore)
         {
-            var raw = settingsStore.GetValue(
+            string raw = settingsStore.GetValue(
                 SettingKey,
                 shouldSync: false,
-                DefaultValue.ToString());
+                DefaultValue.ToString(CultureInfo.InvariantCulture));
 
-            return !bool.TryParse(raw, out var enabled) || enabled;
+            return !bool.TryParse(raw, out bool enabled) || enabled;
         }
     }
 }

--- a/Settings/SettingsStore.cs
+++ b/Settings/SettingsStore.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using YASN.Logging;
 
 namespace YASN.Settings
 {
@@ -19,10 +20,10 @@ namespace YASN.Settings
 
         public void ApplyValues(IEnumerable<SettingField> fields)
         {
-            foreach (var field in fields)
+            foreach (SettingField field in fields)
             {
-                var map = field.ShouldSync ? _syncSettings : _localSettings;
-                if (!map.TryGetValue(field.Key, out var value))
+                Dictionary<string, string> map = field.ShouldSync ? _syncSettings : _localSettings;
+                if (!map.TryGetValue(field.Key, out string? value))
                 {
                     continue;
                 }
@@ -32,7 +33,7 @@ namespace YASN.Settings
                     switch (field.FieldType)
                     {
                         case SettingFieldType.Toggle:
-                            if (bool.TryParse(value, out var boolValue))
+                            if (bool.TryParse(value, out bool boolValue))
                             {
                                 field.BoolValue = boolValue;
                             }
@@ -42,19 +43,23 @@ namespace YASN.Settings
                             break;
                     }
                 }
-                catch
+                catch (FormatException ex)
                 {
-                    // Ignore malformed values and keep defaults
+                    AppLogger.Debug($"Failed to apply setting '{field.Key}': {ex.Message}");
+                }
+                catch (InvalidOperationException ex)
+                {
+                    AppLogger.Debug($"Failed to apply setting '{field.Key}': {ex.Message}");
                 }
             }
         }
 
         public void PersistField(SettingField field)
         {
-            var map = field.ShouldSync ? _syncSettings : _localSettings;
-            var path = field.ShouldSync ? _syncPath : _localPath;
-            var value = field.FieldType == SettingFieldType.Toggle
-                ? field.BoolValue.ToString()
+            Dictionary<string, string> map = field.ShouldSync ? _syncSettings : _localSettings;
+            string path = field.ShouldSync ? _syncPath : _localPath;
+            string value = field.FieldType == SettingFieldType.Toggle
+                ? field.BoolValue.ToString(System.Globalization.CultureInfo.InvariantCulture)
                 : field.Value ?? string.Empty;
 
             map[field.Key] = value;
@@ -63,7 +68,7 @@ namespace YASN.Settings
 
         public string GetValue(string key, bool shouldSync, string defaultValue = "")
         {
-            var map = shouldSync ? _syncSettings : _localSettings;
+            Dictionary<string, string> map = shouldSync ? _syncSettings : _localSettings;
             return map.GetValueOrDefault(key, defaultValue);
         }
 
@@ -72,26 +77,39 @@ namespace YASN.Settings
             errorMessage = string.Empty;
             try
             {
-                var directory = Path.GetDirectoryName(path);
+                string? directory = Path.GetDirectoryName(path);
                 if (!string.IsNullOrEmpty(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }
 
-                var payload = new SettingsExportPayload
+                SettingsExportPayload payload = new SettingsExportPayload
                 {
                     SchemaVersion = 1,
                     SyncSettings = new Dictionary<string, string>(_syncSettings),
                     LocalSettings = new Dictionary<string, string>(_localSettings)
                 };
 
-                var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true });
+                string json = JsonSerializer.Serialize(payload, new JsonSerializerOptions { WriteIndented = true });
                 File.WriteAllText(path, json);
                 return true;
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 errorMessage = ex.Message;
+                AppLogger.Warn($"Failed to export settings to '{path}': {ex.Message}");
+                return false;
+            }
+            catch (JsonException ex)
+            {
+                errorMessage = ex.Message;
+                AppLogger.Warn($"Failed to export settings to '{path}': {ex.Message}");
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                errorMessage = ex.Message;
+                AppLogger.Warn($"Failed to export settings to '{path}': {ex.Message}");
                 return false;
             }
         }
@@ -107,8 +125,8 @@ namespace YASN.Settings
                     return false;
                 }
 
-                var json = File.ReadAllText(path);
-                var payload = JsonSerializer.Deserialize<SettingsExportPayload>(json);
+                string json = File.ReadAllText(path);
+                SettingsExportPayload? payload = JsonSerializer.Deserialize<SettingsExportPayload>(json);
                 if (payload == null)
                 {
                     errorMessage = "Invalid settings file.";
@@ -118,12 +136,12 @@ namespace YASN.Settings
                 _syncSettings.Clear();
                 _localSettings.Clear();
 
-                foreach (var kv in payload.SyncSettings)
+                foreach (KeyValuePair<string, string> kv in payload.SyncSettings)
                 {
                     _syncSettings[kv.Key] = kv.Value ?? string.Empty;
                 }
 
-                foreach (var kv in payload.LocalSettings)
+                foreach (KeyValuePair<string, string> kv in payload.LocalSettings)
                 {
                     _localSettings[kv.Key] = kv.Value ?? string.Empty;
                 }
@@ -132,9 +150,22 @@ namespace YASN.Settings
                 SaveDictionary(_localSettings, _localPath);
                 return true;
             }
-            catch (Exception ex)
+            catch (IOException ex)
             {
                 errorMessage = ex.Message;
+                AppLogger.Warn($"Failed to import settings from '{path}': {ex.Message}");
+                return false;
+            }
+            catch (JsonException ex)
+            {
+                errorMessage = ex.Message;
+                AppLogger.Warn($"Failed to import settings from '{path}': {ex.Message}");
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                errorMessage = ex.Message;
+                AppLogger.Warn($"Failed to import settings from '{path}': {ex.Message}");
                 return false;
             }
         }
@@ -145,13 +176,21 @@ namespace YASN.Settings
             {
                 if (File.Exists(path))
                 {
-                    var json = File.ReadAllText(path);
+                    string json = File.ReadAllText(path);
                     return JsonSerializer.Deserialize<Dictionary<string, string>>(json) ?? new Dictionary<string, string>();
                 }
             }
-            catch
+            catch (IOException ex)
             {
-                // Ignore corrupt files and start fresh
+                AppLogger.Debug($"Failed to load settings dictionary from '{path}': {ex.Message}");
+            }
+            catch (JsonException ex)
+            {
+                AppLogger.Debug($"Failed to load settings dictionary from '{path}': {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to load settings dictionary from '{path}': {ex.Message}");
             }
 
             return new Dictionary<string, string>();
@@ -161,18 +200,26 @@ namespace YASN.Settings
         {
             try
             {
-                var directory = Path.GetDirectoryName(path);
+                string? directory = Path.GetDirectoryName(path);
                 if (!string.IsNullOrEmpty(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }
 
-                var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+                string json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
                 File.WriteAllText(path, json);
             }
-            catch
+            catch (IOException ex)
             {
-                // Swallow IO errors to avoid crashing settings UI
+                AppLogger.Warn($"Failed to save settings dictionary to '{path}': {ex.Message}");
+            }
+            catch (JsonException ex)
+            {
+                AppLogger.Warn($"Failed to save settings dictionary to '{path}': {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Warn($"Failed to save settings dictionary to '{path}': {ex.Message}");
             }
         }
 

--- a/Settings/WebDavSettingsFieldFactory.cs
+++ b/Settings/WebDavSettingsFieldFactory.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace YASN.Settings
 {
     internal sealed class WebDavSettingFields
@@ -85,7 +87,7 @@ namespace YASN.Settings
                     Title = "Attachment Sync Threshold (MB)",
                     Description = "Files up to this size are copied and synced; larger files keep file-system paths.",
                     FieldType = SettingFieldType.Text,
-                    Value = AttachmentSyncSettings.DefaultAutoSyncThresholdMb.ToString(),
+                    Value = AttachmentSyncSettings.DefaultAutoSyncThresholdMb.ToString(CultureInfo.InvariantCulture),
                     ShouldSync = true
                 }
             };

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -1,6 +1,9 @@
-﻿using System.IO;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using System.Windows.Threading;
 using YASN.Settings;
 using YASN.Sync.WebDav;
@@ -33,11 +36,11 @@ namespace YASN
         private void BuildModules()
         {
             ViewModel.Modules.Clear();
-            var allFields = new List<SettingField>();
+            List<SettingField> allFields = new List<SettingField>();
 
-            var generalFields = GeneralSettingsFieldFactory.Create();
-            var editorFields = EditorSettingsFieldFactory.Create();
-            var webDavFields = WebDavSettingsFieldFactory.Create();
+            GeneralSettingFields generalFields = GeneralSettingsFieldFactory.Create();
+            EditorSettingFields editorFields = EditorSettingsFieldFactory.Create();
+            WebDavSettingFields webDavFields = WebDavSettingsFieldFactory.Create();
 
             allFields.Add(generalFields.AutoStartField);
             allFields.Add(generalFields.AutoCollapseNoteChromeField);
@@ -55,7 +58,7 @@ namespace YASN
             allFields.Add(webDavFields.AttachmentAutoSyncField);
             allFields.Add(webDavFields.AttachmentThresholdField);
 
-            var generalModule = new SettingModule
+            SettingModule generalModule = new SettingModule
             {
                 Key = "general",
                 Title = "通用",
@@ -68,7 +71,7 @@ namespace YASN
             generalModule.Fields.Add(generalFields.PreviewStyleField);
             generalModule.Fields.Add(generalFields.DataDirectoryField);
 
-            var editorModule = new SettingModule
+            SettingModule editorModule = new SettingModule
             {
                 Key = "editor",
                 Title = "编辑",
@@ -76,7 +79,7 @@ namespace YASN
             };
             editorModule.Fields.Add(editorFields.EnterModeField);
 
-            var webDavModule = new SettingModule
+            SettingModule webDavModule = new SettingModule
             {
                 Key = "webdav",
                 Title = "云同步",
@@ -94,10 +97,10 @@ namespace YASN
             _settingsStore.ApplyValues(allFields);
             generalFields.FloatingTaskbarVisibilityField.Value =
                 FloatingWindowTaskbarVisibility.NormalizeValue(generalFields.FloatingTaskbarVisibilityField.Value);
-            var previewStyleNormalized = ConfigurePreviewStyleField(generalFields.PreviewStyleField);
-            var normalizedEditorEnterMode = EditorDisplayModeSettings.ToValue(
+            bool previewStyleNormalized = ConfigurePreviewStyleField(generalFields.PreviewStyleField);
+            string normalizedEditorEnterMode = EditorDisplayModeSettings.ToValue(
                 EditorDisplayModeSettings.ParseValue(editorFields.EnterModeField.Value));
-            var editorModeNormalized = !string.Equals(
+            bool editorModeNormalized = !string.Equals(
                 editorFields.EnterModeField.Value,
                 normalizedEditorEnterMode,
                 StringComparison.Ordinal);
@@ -125,7 +128,7 @@ namespace YASN
             };
             generalFields.PreviewStyleField.OnChanged = field =>
             {
-                var resolved = PreviewStyleManager.ResolveStyle(field.Value);
+                string resolved = PreviewStyleManager.ResolveStyle(field.Value);
                 if (!string.Equals(field.Value, resolved, StringComparison.OrdinalIgnoreCase))
                 {
                     field.Value = resolved;
@@ -170,7 +173,7 @@ namespace YASN
             webDavFields.AttachmentAutoSyncField.OnChanged = f => _settingsStore.PersistField(f);
             webDavFields.AttachmentThresholdField.OnChanged = f =>
             {
-                var normalized = AttachmentSyncSettings.ParseThresholdMb(f.Value).ToString();
+                string normalized = AttachmentSyncSettings.ParseThresholdMb(f.Value).ToString(CultureInfo.InvariantCulture);
                 if (!string.Equals(f.Value, normalized, StringComparison.Ordinal))
                 {
                     f.Value = normalized;
@@ -218,8 +221,8 @@ namespace YASN
                 ExecuteAsync = async () =>
                 {
                     var options = BuildWebDavOptions(webDavFields.ServerUrlField, webDavFields.UserField, webDavFields.PasswordField);
-                    using var client = new WebDavSyncClient(options);
-                    var ok = await client.TestConnectionAsync(NormalizeDirectory(webDavFields.RemoteField.Value));
+                    using WebDavSyncClient client = new WebDavSyncClient(options);
+                    bool ok = await client.TestConnectionAsync(NormalizeDirectory(webDavFields.RemoteField.Value)).ConfigureAwait(false);
                     return ok ? "连接成功" : $"连接失败: {client.LastError ?? "未知错误"}";
                 }
             });
@@ -235,11 +238,11 @@ namespace YASN
                     }
 
                     var options = BuildWebDavOptions(webDavFields.ServerUrlField, webDavFields.UserField, webDavFields.PasswordField);
-                    var client = new WebDavSyncClient(options);
-                    var enabled = webDavFields.AutoSyncField.BoolValue;
-                    var intervalSeconds = ParseSyncInterval(webDavFields.SyncIntervalField.Value);
+                    WebDavSyncClient client = new WebDavSyncClient(options);
+                    bool enabled = webDavFields.AutoSyncField.BoolValue;
+                    int intervalSeconds = ParseSyncInterval(webDavFields.SyncIntervalField.Value);
                     ApplySyncInterval(webDavFields.SyncIntervalField.Value);
-                    var configured = await App.SyncManager.ConfigureAsync(client, NormalizeDirectory(webDavFields.RemoteField.Value), enabled, intervalSeconds);
+                    bool configured = await App.SyncManager.ConfigureAsync(client, NormalizeDirectory(webDavFields.RemoteField.Value), enabled, intervalSeconds).ConfigureAwait(false);
                     return configured ? "WebDAV 已保存并生效。" : "WebDAV 配置失败。";
                 }
             });
@@ -252,7 +255,7 @@ namespace YASN
 
         private string ExportSettings()
         {
-            var dialog = new SaveFileDialog
+            SaveFileDialog dialog = new SaveFileDialog
             {
                 Title = "Export Settings",
                 Filter = "YASN Settings (*.yasnsettings.json)|*.yasnsettings.json|JSON (*.json)|*.json|All Files (*.*)|*.*",
@@ -264,13 +267,13 @@ namespace YASN
                 return "已取消导出。";
             }
 
-            var ok = _settingsStore.ExportToFile(dialog.FileName, out var errorMessage);
+            bool ok = _settingsStore.ExportToFile(dialog.FileName, out string? errorMessage);
             return ok ? $"设置已导出到: {dialog.FileName}" : $"导出失败: {errorMessage}";
         }
 
         private string ImportSettings()
         {
-            var dialog = new OpenFileDialog
+            OpenFileDialog dialog = new OpenFileDialog
             {
                 Title = "Import Settings",
                 Filter = "YASN Settings (*.yasnsettings.json)|*.yasnsettings.json|JSON (*.json)|*.json|All Files (*.*)|*.*",
@@ -283,7 +286,7 @@ namespace YASN
                 return "已取消导入。";
             }
 
-            var ok = _settingsStore.ImportFromFile(dialog.FileName, out var errorMessage);
+            bool ok = _settingsStore.ImportFromFile(dialog.FileName, out string? errorMessage);
             if (!ok)
             {
                 return $"导入失败: {errorMessage}";
@@ -295,7 +298,7 @@ namespace YASN
 
         private string ApplyDataDirectory(SettingField dataDirectoryField)
         {
-            if (!AppPaths.TryNormalizeDataDirectory(dataDirectoryField.Value, out var normalizedPath, out var errorMessage))
+            if (!AppPaths.TryNormalizeDataDirectory(dataDirectoryField.Value, out string? normalizedPath, out string? errorMessage))
             {
                 return $"数据目录无效: {errorMessage}";
             }
@@ -307,7 +310,7 @@ namespace YASN
 
         private string BrowseDataDirectory(SettingField dataDirectoryField)
         {
-            if (TryBrowseDataDirectory(dataDirectoryField, out var selectedPath))
+            if (TryBrowseDataDirectory(dataDirectoryField, out string? selectedPath))
             {
                 dataDirectoryField.Value = selectedPath;
                 return $"已选择数据目录: {selectedPath}";
@@ -323,7 +326,7 @@ namespace YASN
                 return;
             }
 
-            if (TryBrowseDataDirectory(field, out var selectedPath))
+            if (TryBrowseDataDirectory(field, out string? selectedPath))
             {
                 field.Value = selectedPath;
             }
@@ -333,13 +336,13 @@ namespace YASN
         {
             selectedPath = string.Empty;
 
-            var initialPath = AppPaths.DataDirectory;
-            if (!string.IsNullOrWhiteSpace(field.Value) && AppPaths.TryNormalizeDataDirectory(field.Value, out var normalized, out _))
+            string initialPath = AppPaths.DataDirectory;
+            if (!string.IsNullOrWhiteSpace(field.Value) && AppPaths.TryNormalizeDataDirectory(field.Value, out string? normalized, out _))
             {
                 initialPath = normalized;
             }
 
-            using var dialog = new FolderBrowserDialog
+            using FolderBrowserDialog dialog = new FolderBrowserDialog
             {
                 Description = "选择 YASN 数据目录",
                 UseDescriptionForTitle = true,
@@ -372,8 +375,8 @@ namespace YASN
 
         private void HandleAutoStartChanged(SettingField field)
         {
-            var enabled = field.BoolValue;
-            var success = enabled
+            bool enabled = field.BoolValue;
+            bool success = enabled
                 ? AutoStartManager.EnableAutoStart()
                 : AutoStartManager.DisableAutoStart();
 
@@ -398,20 +401,61 @@ namespace YASN
                         module.Status = "执行中...";
                     }
 
-                    var message = await (action.ExecuteAsync?.Invoke() ?? Task.FromResult(string.Empty));
+                    string message = await ((action.ExecuteAsync?.Invoke() ?? Task.FromResult(string.Empty)).ConfigureAwait(false));
 
                     if (module != null)
                     {
                         module.Status = message;
                     }
                 }
-                catch (Exception ex)
+                catch (HttpRequestException ex)
                 {
-                    var module = FindModuleForAction(action);
+                    SettingModule? module = FindModuleForAction(action);
                     if (module != null)
                     {
                         module.Status = $"操作失败: {ex.Message}";
                     }
+                    Logging.AppLogger.Warn($"Settings action '{action.Key}' failed: {ex.Message}");
+                }
+                catch (IOException ex)
+                {
+                    SettingModule? module = FindModuleForAction(action);
+                    if (module != null)
+                    {
+                        module.Status = $"鎿嶄綔澶辫触: {ex.Message}";
+                    }
+
+                    Logging.AppLogger.Warn($"Settings action '{action.Key}' failed: {ex.Message}");
+                }
+                catch (InvalidOperationException ex)
+                {
+                    SettingModule? module = FindModuleForAction(action);
+                    if (module != null)
+                    {
+                        module.Status = $"鎿嶄綔澶辫触: {ex.Message}";
+                    }
+
+                    Logging.AppLogger.Warn($"Settings action '{action.Key}' failed: {ex.Message}");
+                }
+                catch (TaskCanceledException ex)
+                {
+                    SettingModule? module = FindModuleForAction(action);
+                    if (module != null)
+                    {
+                        module.Status = $"鎿嶄綔澶辫触: {ex.Message}";
+                    }
+
+                    Logging.AppLogger.Warn($"Settings action '{action.Key}' failed: {ex.Message}");
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    SettingModule? module = FindModuleForAction(action);
+                    if (module != null)
+                    {
+                        module.Status = $"鎿嶄綔澶辫触: {ex.Message}";
+                    }
+
+                    Logging.AppLogger.Warn($"Settings action '{action.Key}' failed: {ex.Message}");
                 }
                 finally
                 {
@@ -420,14 +464,14 @@ namespace YASN
             }
         }
 
-        private SettingModule FindModuleForAction(SettingAction action)
+        private SettingModule? FindModuleForAction(SettingAction action)
         {
             return ViewModel.Modules.FirstOrDefault(m => m.Actions.Contains(action));
         }
 
         private static void ApplyFloatingWindowTaskbarVisibilityToOpenWindows()
         {
-            foreach (var note in NoteManager.Instance.Notes)
+            foreach (NoteData note in NoteManager.Instance.Notes)
             {
                 note.Window?.RefreshTaskbarVisibilityFromSettings();
             }
@@ -435,7 +479,7 @@ namespace YASN
 
         private static void ApplyNoteChromeAutoCollapseToOpenWindows()
         {
-            foreach (var note in NoteManager.Instance.Notes)
+            foreach (NoteData note in NoteManager.Instance.Notes)
             {
                 note.Window?.RefreshChromeBehaviorFromSettings();
             }
@@ -443,7 +487,7 @@ namespace YASN
 
         private static void ApplyPreviewStyleToOpenWindows()
         {
-            foreach (var note in NoteManager.Instance.Notes)
+            foreach (NoteData note in NoteManager.Instance.Notes)
             {
                 note.Window?.RefreshPreviewStyleFromSettings();
             }
@@ -452,7 +496,7 @@ namespace YASN
         private static bool ConfigurePreviewStyleField(SettingField field)
         {
             field.Options.Clear();
-            foreach (var stylePath in PreviewStyleManager.ListStyles())
+            foreach (string stylePath in PreviewStyleManager.ListStyles())
             {
                 field.Options.Add(new SettingOption
                 {
@@ -461,15 +505,15 @@ namespace YASN
                 });
             }
 
-            var resolved = PreviewStyleManager.ResolveStyle(field.Value);
-            var changed = !string.Equals(field.Value, resolved, StringComparison.OrdinalIgnoreCase);
+            string resolved = PreviewStyleManager.ResolveStyle(field.Value);
+            bool changed = !string.Equals(field.Value, resolved, StringComparison.OrdinalIgnoreCase);
             field.Value = resolved;
             return changed;
         }
 
         private void ApplyLogSize(string value)
         {
-            if (int.TryParse(value, out var kb) && kb > 0)
+            if (int.TryParse(value, out int kb) && kb > 0)
             {
                 Logging.AppLogger.SetMaxSizeKb(kb);
                 Logging.AppLogger.Debug($"日志大小限制设置为 {kb} KB");
@@ -482,15 +526,15 @@ namespace YASN
 
         private void ApplySyncInterval(string value)
         {
-            var seconds = ParseSyncInterval(value);
+            int seconds = ParseSyncInterval(value);
             App.SyncManager?.SetIntervalSeconds(seconds);
             Logging.AppLogger.Debug($"同步间隔设为 {seconds} 秒");
         }
 
-        private int ParseSyncInterval(string value)
+        private static int ParseSyncInterval(string value)
         {
             const int defaultSeconds = 300;
-            if (int.TryParse(value, out var seconds) && seconds > 0)
+            if (int.TryParse(value, out int seconds) && seconds > 0)
             {
                 return Math.Max(10, seconds);
             }
@@ -518,15 +562,15 @@ namespace YASN
                     return;
                 }
 
-                var container = ModuleItemsControl.ItemContainerGenerator.ContainerFromItem(module) as FrameworkElement;
+                FrameworkElement? container = ModuleItemsControl.ItemContainerGenerator.ContainerFromItem(module) as FrameworkElement;
                 if (container == null)
                 {
                     return;
                 }
 
                 container.UpdateLayout();
-                var transform = container.TransformToAncestor(ModuleScrollViewer);
-                var point = transform.Transform(new Point(0, 0));
+                GeneralTransform transform = container.TransformToAncestor(ModuleScrollViewer);
+                Point point = transform.Transform(new Point(0, 0));
                 ModuleScrollViewer.ScrollToVerticalOffset(point.Y + ModuleScrollViewer.VerticalOffset);
             }), DispatcherPriority.Background);
         }

--- a/Sync/Abstractions/ISyncClient.cs
+++ b/Sync/Abstractions/ISyncClient.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading.Tasks;
-
 namespace YASN.Sync
 {
     /// <summary>
@@ -17,6 +14,6 @@ namespace YASN.Sync
         Task<bool> DownloadFileAsync(string remoteFilePath, string localFilePath);
         Task<bool> FileExistsAsync(string remoteFilePath);
         Task<DateTime?> GetFileLastModifiedAsync(string remoteFilePath);
-        Task<string> GetFileHashAsync(string remoteFilePath);
+        Task<string?> GetFileHashAsync(string remoteFilePath);
     }
 }

--- a/Sync/FileHashUtil.cs
+++ b/Sync/FileHashUtil.cs
@@ -1,45 +1,89 @@
-using System;
+using System.Globalization;
 using System.IO;
+using System.Security;
 using System.Security.Cryptography;
 using System.Text;
+using YASN.Logging;
 
 namespace YASN.Sync
 {
     public static class FileHashUtil
     {
-        public static string ComputeFileHash(string filePath)
+        public static string? ComputeFileHash(string filePath)
         {
             try
             {
-                using var stream = File.OpenRead(filePath);
+                using FileStream stream = File.OpenRead(filePath);
                 return ComputeStreamHash(stream);
             }
-            catch
+            catch (IOException ex)
             {
+                AppLogger.Debug($"Failed to hash file '{filePath}': {ex.Message}");
+                return null;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to hash file '{filePath}': {ex.Message}");
+                return null;
+            }
+            catch (SecurityException ex)
+            {
+                AppLogger.Debug($"Failed to hash file '{filePath}': {ex.Message}");
+                return null;
+            }
+            catch (NotSupportedException ex)
+            {
+                AppLogger.Debug($"Failed to hash file '{filePath}': {ex.Message}");
+                return null;
+            }
+            catch (ArgumentException ex)
+            {
+                AppLogger.Debug($"Failed to hash file '{filePath}': {ex.Message}");
                 return null;
             }
         }
 
-        public static string ComputeStreamHash(Stream stream)
+        public static string? ComputeStreamHash(Stream stream)
         {
             try
             {
-                using var sha = SHA256.Create();
-                var hash = sha.ComputeHash(stream);
+                using SHA256 sha = SHA256.Create();
+                byte[] hash = sha.ComputeHash(stream);
                 return ToHex(hash);
             }
-            catch
+            catch (CryptographicException ex)
             {
+                AppLogger.Debug($"Failed to hash stream: {ex.Message}");
+                return null;
+            }
+            catch (IOException ex)
+            {
+                AppLogger.Debug($"Failed to hash stream: {ex.Message}");
+                return null;
+            }
+            catch (NotSupportedException ex)
+            {
+                AppLogger.Debug($"Failed to hash stream: {ex.Message}");
+                return null;
+            }
+            catch (ObjectDisposedException ex)
+            {
+                AppLogger.Debug($"Failed to hash stream: {ex.Message}");
+                return null;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Debug($"Failed to hash stream: {ex.Message}");
                 return null;
             }
         }
 
         private static string ToHex(byte[] bytes)
         {
-            var sb = new StringBuilder(bytes.Length * 2);
-            foreach (var b in bytes)
+            StringBuilder sb = new StringBuilder(bytes.Length * 2);
+            foreach (byte b in bytes)
             {
-                sb.Append(b.ToString("x2"));
+                sb.Append(b.ToString("x2", CultureInfo.InvariantCulture));
             }
             return sb.ToString();
         }

--- a/Sync/SignatureStore.cs
+++ b/Sync/SignatureStore.cs
@@ -1,7 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using YASN.Logging;
 
 namespace YASN.Sync
 {
@@ -19,9 +18,9 @@ namespace YASN.Sync
             _signatures = LoadFromFile(path);
         }
 
-        public string Get(string fileName)
+        public string? Get(string fileName)
         {
-            return fileName != null && _signatures.TryGetValue(fileName, out var hash) ? hash : null;
+            return fileName != null && _signatures.TryGetValue(fileName, out string? hash) ? hash : null;
         }
 
         public void Set(string fileName, string hash)
@@ -38,13 +37,13 @@ namespace YASN.Sync
 
         public void Save()
         {
-            var directory = Path.GetDirectoryName(_path);
+            string? directory = Path.GetDirectoryName(_path);
             if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
             {
                 Directory.CreateDirectory(directory);
             }
 
-            var json = JsonSerializer.Serialize(_signatures);
+            string json = JsonSerializer.Serialize(_signatures);
             File.WriteAllText(_path, json);
         }
 
@@ -57,14 +56,25 @@ namespace YASN.Sync
                     return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 }
 
-                var json = File.ReadAllText(path);
-                var data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+                string json = File.ReadAllText(path);
+                Dictionary<string, string>? data = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
                 return data != null
                     ? new Dictionary<string, string>(data, StringComparer.OrdinalIgnoreCase)
                     : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
-            catch
+            catch (IOException ex)
             {
+                AppLogger.Warn($"Failed to load signature store from '{path}': {ex.Message}");
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+            catch (JsonException ex)
+            {
+                AppLogger.Warn($"Failed to load signature store from '{path}': {ex.Message}");
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Warn($"Failed to load signature store from '{path}': {ex.Message}");
                 return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
         }

--- a/Sync/SyncManager.cs
+++ b/Sync/SyncManager.cs
@@ -1,10 +1,7 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Timers;
-using YASN;
+using System.Net.Http;
+using System.Text.Json;
+using System.Windows;
 using YASN.Logging;
 using Application = System.Windows.Application;
 using MessageBox = System.Windows.MessageBox;
@@ -60,7 +57,7 @@ namespace YASN.Sync
             };
             SetIntervalSeconds(_intervalSeconds);
 
-            _syncTimer.Elapsed += async (_, __) => await SyncAsync();
+            _syncTimer.Elapsed += async (_, __) => await SyncAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -78,7 +75,7 @@ namespace YASN.Sync
             _remoteDirectory = NormalizeRemoteDirectory(remoteDirectory);
             SetIntervalSeconds(intervalSeconds);
 
-            if (!await _client.EnsureDirectoryAsync(_remoteDirectory))
+            if (!await _client.EnsureDirectoryAsync(_remoteDirectory).ConfigureAwait(false))
             {
                 return false;
             }
@@ -130,19 +127,16 @@ namespace YASN.Sync
                 return new SyncResult { Success = false, Message = "Sync not enabled" };
             }
 
-            var result = new SyncResult { Success = true };
+            SyncResult result = new SyncResult { Success = true };
 
             try
             {
-                _remoteSignatures = await LoadRemoteSignaturesAsync();
-                var localEntries = BuildLocalSyncEntries();
-                var allKeys = new HashSet<string>(localEntries.Keys, StringComparer.OrdinalIgnoreCase);
-                foreach (var key in _remoteSignatures.Keys)
+                _remoteSignatures = await LoadRemoteSignaturesAsync().ConfigureAwait(false);
+                Dictionary<string, string> localEntries = BuildLocalSyncEntries();
+                HashSet<string> allKeys = new HashSet<string>(localEntries.Keys, StringComparer.OrdinalIgnoreCase);
+                foreach (string key in _remoteSignatures.Keys.Where(key => !string.Equals(key, ManifestFileName, StringComparison.OrdinalIgnoreCase) && IsSyncableKey(key)))
                 {
-                    if (!string.Equals(key, ManifestFileName, StringComparison.OrdinalIgnoreCase) && IsSyncableKey(key))
-                    {
-                        allKeys.Add(key);
-                    }
+                    allKeys.Add(key);
                 }
 
                 if (allKeys.Count == 0)
@@ -152,125 +146,133 @@ namespace YASN.Sync
                     return result;
                 }
 
-                var messages = new List<string>();
-                var signatureDirty = false;
-                var shouldReloadNotes = false;
-                var shouldRefreshPreviewStyles = false;
+                List<string> messages = new List<string>();
+                bool signatureDirty = false;
+                bool shouldReloadNotes = false;
+                bool shouldRefreshPreviewStyles = false;
 
-                foreach (var key in allKeys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase))
+                foreach (string? key in allKeys.OrderBy(k => k, StringComparer.OrdinalIgnoreCase))
                 {
-                    var localPath = localEntries.TryGetValue(key, out var existingPath)
+                    string localPath = localEntries.TryGetValue(key, out string? existingPath)
                         ? existingPath
                         : ToLocalPath(key);
-                    var remotePath = BuildRemotePath(key);
-                    var localExists = File.Exists(localPath);
-                    var remoteExists = _remoteSignatures.ContainsKey(key) || await _client.FileExistsAsync(remotePath);
+                    string remotePath = BuildRemotePath(key);
+                    bool localExists = File.Exists(localPath);
+                    bool remoteExists = _remoteSignatures.ContainsKey(key) || await _client.FileExistsAsync(remotePath).ConfigureAwait(false);
 
-                    if (localExists && remoteExists)
+                    switch (localExists)
                     {
-                        var localHash = FileHashUtil.ComputeFileHash(localPath);
-                        if (!string.IsNullOrEmpty(localHash))
+                        case true when remoteExists:
                         {
-                            _signatureStore.Set(key, localHash);
-                            signatureDirty = true;
-                        }
-
-                        _remoteSignatures.TryGetValue(key, out var remoteHash);
-                        var remoteLastModified = await _client.GetFileLastModifiedAsync(remotePath);
-                        var localLastModified = File.GetLastWriteTime(localPath);
-                        var remoteIsNewer = remoteLastModified.HasValue && remoteLastModified.Value > localLastModified;
-
-                        if (!string.IsNullOrEmpty(localHash) &&
-                            !string.IsNullOrEmpty(remoteHash) &&
-                            string.Equals(localHash, remoteHash, StringComparison.OrdinalIgnoreCase))
-                        {
-                            if (remoteLastModified.HasValue && remoteLastModified.Value > localLastModified)
+                            string localHash = FileHashUtil.ComputeFileHash(localPath);
+                            if (!string.IsNullOrEmpty(localHash))
                             {
-                                File.SetLastWriteTime(localPath, remoteLastModified.Value);
+                                _signatureStore.Set(key, localHash);
+                                signatureDirty = true;
+                            }
+
+                            _remoteSignatures.TryGetValue(key, out string? remoteHash);
+                            DateTime? remoteLastModified = await _client.GetFileLastModifiedAsync(remotePath).ConfigureAwait(false);
+                            DateTime localLastModified = File.GetLastWriteTime(localPath);
+                            bool remoteIsNewer = remoteLastModified.HasValue && remoteLastModified.Value > localLastModified;
+
+                            if (!string.IsNullOrEmpty(localHash) &&
+                                !string.IsNullOrEmpty(remoteHash) &&
+                                string.Equals(localHash, remoteHash, StringComparison.OrdinalIgnoreCase))
+                            {
+                                if (remoteLastModified.HasValue && remoteLastModified.Value > localLastModified)
+                                {
+                                    File.SetLastWriteTime(localPath, remoteLastModified.Value);
+                                }
+
+                                continue;
+                            }
+
+                            switch (remoteIsNewer)
+                            {
+                                // Both sides changed and remote timestamp wins -> explicit conflict prompt.
+                                case true when
+                                    !string.IsNullOrEmpty(localHash) &&
+                                    !string.IsNullOrEmpty(remoteHash) &&
+                                    !string.Equals(localHash, remoteHash, StringComparison.OrdinalIgnoreCase):
+                                {
+                                    AppLogger.Warn($"Sync conflict detected for {key} (local {localLastModified}, remote {remoteLastModified.Value}).");
+                                    ConflictResolutionAction resolution = await PromptConflictAsync(key, localLastModified, remoteLastModified.Value).ConfigureAwait(false);
+                                    if (resolution == ConflictResolutionAction.DownloadRemote)
+                                    {
+                                        if (await DownloadFileAsync(remotePath, localPath).ConfigureAwait(false))
+                                        {
+                                            messages.Add($"{key} downloaded (conflict)");
+                                            result.FilesDownloaded += 1;
+                                            UpdateLocalSignature(localPath, key, ref signatureDirty);
+                                            shouldReloadNotes |= ShouldReloadNotes(key);
+                                            shouldRefreshPreviewStyles |= ShouldRefreshPreviewStyles(key);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if (await UploadFileAsync(localPath, key).ConfigureAwait(false))
+                                        {
+                                            messages.Add($"{key} uploaded (conflict)");
+                                            UpdateLocalSignature(localPath, key, ref signatureDirty);
+                                            result.FilesUploaded += 1;
+                                        }
+                                    }
+
+                                    continue;
+                                }
+                                // No hard conflict: choose newer side.
+                                case true:
+                                {
+                                    if (await DownloadFileAsync(remotePath, localPath).ConfigureAwait(false))
+                                    {
+                                        messages.Add($"{key} downloaded");
+                                        result.FilesDownloaded += 1;
+                                        UpdateLocalSignature(localPath, key, ref signatureDirty);
+                                        shouldReloadNotes |= ShouldReloadNotes(key);
+                                        shouldRefreshPreviewStyles |= ShouldRefreshPreviewStyles(key);
+                                    }
+
+                                    break;
+                                }
+                                default:
+                                {
+                                    if (await UploadFileAsync(localPath, key).ConfigureAwait(false))
+                                    {
+                                        messages.Add($"{key} uploaded");
+                                        UpdateLocalSignature(localPath, key, ref signatureDirty);
+                                        result.FilesUploaded += 1;
+                                    }
+
+                                    break;
+                                }
                             }
 
                             continue;
                         }
-
-                        // Both sides changed and remote timestamp wins -> explicit conflict prompt.
-                        if (remoteIsNewer &&
-                            !string.IsNullOrEmpty(localHash) &&
-                            !string.IsNullOrEmpty(remoteHash) &&
-                            !string.Equals(localHash, remoteHash, StringComparison.OrdinalIgnoreCase))
+                        // First-time publish from local.
+                        case true when !remoteExists:
                         {
-                            AppLogger.Warn($"Sync conflict detected for {key} (local {localLastModified}, remote {remoteLastModified.Value}).");
-                            var resolution = await PromptConflictAsync(key, localLastModified, remoteLastModified.Value);
-                            if (resolution == ConflictResolutionAction.DownloadRemote)
+                            if (await UploadFileAsync(localPath, key).ConfigureAwait(false))
                             {
-                                if (await DownloadFileAsync(remotePath, localPath))
-                                {
-                                    messages.Add($"{key} downloaded (conflict)");
-                                    result.FilesDownloaded += 1;
-                                    UpdateLocalSignature(localPath, key, ref signatureDirty);
-                                    shouldReloadNotes |= ShouldReloadNotes(key);
-                                    shouldRefreshPreviewStyles |= ShouldRefreshPreviewStyles(key);
-                                }
-                            }
-                            else
-                            {
-                                if (await UploadFileAsync(localPath, key))
-                                {
-                                    messages.Add($"{key} uploaded (conflict)");
-                                    UpdateLocalSignature(localPath, key, ref signatureDirty);
-                                    result.FilesUploaded += 1;
-                                }
-                            }
-
-                            continue;
-                        }
-
-                        // No hard conflict: choose newer side.
-                        if (remoteIsNewer)
-                        {
-                            if (await DownloadFileAsync(remotePath, localPath))
-                            {
-                                messages.Add($"{key} downloaded");
-                                result.FilesDownloaded += 1;
-                                UpdateLocalSignature(localPath, key, ref signatureDirty);
-                                shouldReloadNotes |= ShouldReloadNotes(key);
-                                shouldRefreshPreviewStyles |= ShouldRefreshPreviewStyles(key);
-                            }
-                        }
-                        else
-                        {
-                            if (await UploadFileAsync(localPath, key))
-                            {
-                                messages.Add($"{key} uploaded");
+                                messages.Add($"{key} initial upload");
                                 UpdateLocalSignature(localPath, key, ref signatureDirty);
                                 result.FilesUploaded += 1;
                             }
+
+                            continue;
                         }
-
-                        continue;
-                    }
-
-                    // First-time publish from local.
-                    if (localExists && !remoteExists)
-                    {
-                        if (await UploadFileAsync(localPath, key))
+                        // First-time materialization from remote.
+                        case false when remoteExists:
                         {
-                            messages.Add($"{key} initial upload");
+                            if (!await DownloadFileAsync(remotePath, localPath).ConfigureAwait(false)) continue;
+                            messages.Add($"{key} downloaded (new)");
+                            result.FilesDownloaded += 1;
                             UpdateLocalSignature(localPath, key, ref signatureDirty);
-                            result.FilesUploaded += 1;
+                            shouldReloadNotes |= ShouldReloadNotes(key);
+                            shouldRefreshPreviewStyles |= ShouldRefreshPreviewStyles(key);
+                            break;
                         }
-
-                        continue;
-                    }
-
-                    // First-time materialization from remote.
-                    if (!localExists && remoteExists)
-                    {
-                        if (!await DownloadFileAsync(remotePath, localPath)) continue;
-                        messages.Add($"{key} downloaded (new)");
-                        result.FilesDownloaded += 1;
-                        UpdateLocalSignature(localPath, key, ref signatureDirty);
-                        shouldReloadNotes |= ShouldReloadNotes(key);
-                        shouldRefreshPreviewStyles |= ShouldRefreshPreviewStyles(key);
                     }
                 }
 
@@ -286,7 +288,7 @@ namespace YASN.Sync
                 {
                     await Application.Current.Dispatcher.InvokeAsync(() =>
                     {
-                        foreach (var note in NoteManager.Instance.Notes)
+                        foreach (NoteData note in NoteManager.Instance.Notes)
                         {
                             note.Window?.RefreshPreviewStyleFromSettings();
                         }
@@ -296,14 +298,44 @@ namespace YASN.Sync
                 if (signatureDirty)
                 {
                     _signatureStore.Save();
-                    await UploadSignatureFileAsync();
+                    await UploadSignatureFileAsync().ConfigureAwait(false);
                 }
 
                 LastSyncTime = DateTime.Now;
                 result.Message = messages.Count > 0 ? string.Join("; ", messages) : "No changes";
                 AppLogger.Debug($"Sync completed: {result.Message} (Uploaded: {result.FilesUploaded}, Downloaded: {result.FilesDownloaded})");
             }
-            catch (Exception ex)
+            catch (HttpRequestException ex)
+            {
+                result.Success = false;
+                result.Message = $"Sync failed: {ex.Message}";
+                AppLogger.Warn($"Sync error: {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                result.Success = false;
+                result.Message = $"Sync failed: {ex.Message}";
+                AppLogger.Warn($"Sync error: {ex.Message}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                result.Success = false;
+                result.Message = $"Sync failed: {ex.Message}";
+                AppLogger.Warn($"Sync error: {ex.Message}");
+            }
+            catch (JsonException ex)
+            {
+                result.Success = false;
+                result.Message = $"Sync failed: {ex.Message}";
+                AppLogger.Warn($"Sync error: {ex.Message}");
+            }
+            catch (TaskCanceledException ex)
+            {
+                result.Success = false;
+                result.Message = $"Sync failed: {ex.Message}";
+                AppLogger.Warn($"Sync error: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
             {
                 result.Success = false;
                 result.Message = $"Sync failed: {ex.Message}";
@@ -324,18 +356,18 @@ namespace YASN.Sync
                 return false;
             }
 
-            var anyUploaded = false;
-            var signatureDirty = false;
-            foreach (var (key, filePath) in BuildLocalSyncEntries())
+            bool anyUploaded = false;
+            bool signatureDirty = false;
+            foreach ((string key, string filePath) in BuildLocalSyncEntries())
             {
-                anyUploaded |= await UploadFileAsync(filePath, key);
+                anyUploaded |= await UploadFileAsync(filePath, key).ConfigureAwait(false);
                 UpdateLocalSignature(filePath, key, ref signatureDirty);
             }
 
             if (signatureDirty)
             {
                 _signatureStore.Save();
-                await UploadSignatureFileAsync();
+                await UploadSignatureFileAsync().ConfigureAwait(false);
             }
 
             return anyUploaded;
@@ -352,12 +384,12 @@ namespace YASN.Sync
                 return false;
             }
 
-            var anyDownloaded = false;
-            var signatureDirty = false;
-            var shouldReloadNotes = false;
-            var shouldRefreshPreviewStyles = false;
-            _remoteSignatures = await LoadRemoteSignaturesAsync();
-            foreach (var kv in _remoteSignatures)
+            bool anyDownloaded = false;
+            bool signatureDirty = false;
+            bool shouldReloadNotes = false;
+            bool shouldRefreshPreviewStyles = false;
+            _remoteSignatures = await LoadRemoteSignaturesAsync().ConfigureAwait(false);
+            foreach (KeyValuePair<string, string> kv in _remoteSignatures)
             {
                 if (string.Equals(kv.Key, ManifestFileName, StringComparison.OrdinalIgnoreCase))
                 {
@@ -369,16 +401,14 @@ namespace YASN.Sync
                     continue;
                 }
 
-                var localPath = ToLocalPath(kv.Key);
-                var remotePath = BuildRemotePath(kv.Key);
-                if (await DownloadFileAsync(remotePath, localPath))
-                {
-                    anyDownloaded = true;
-                    _signatureStore.Set(kv.Key, kv.Value);
-                    signatureDirty = true;
-                    shouldReloadNotes |= ShouldReloadNotes(kv.Key);
-                    shouldRefreshPreviewStyles |= ShouldRefreshPreviewStyles(kv.Key);
-                }
+                string localPath = ToLocalPath(kv.Key);
+                string remotePath = BuildRemotePath(kv.Key);
+                if (!await DownloadFileAsync(remotePath, localPath).ConfigureAwait(false)) continue;
+                anyDownloaded = true;
+                _signatureStore.Set(kv.Key, kv.Value);
+                signatureDirty = true;
+                shouldReloadNotes |= ShouldReloadNotes(kv.Key);
+                shouldRefreshPreviewStyles |= ShouldRefreshPreviewStyles(kv.Key);
             }
 
             if (shouldReloadNotes)
@@ -393,7 +423,7 @@ namespace YASN.Sync
             {
                 await Application.Current.Dispatcher.InvokeAsync(() =>
                 {
-                    foreach (var note in NoteManager.Instance.Notes)
+                    foreach (NoteData note in NoteManager.Instance.Notes)
                     {
                         note.Window?.RefreshPreviewStyleFromSettings();
                     }
@@ -403,7 +433,7 @@ namespace YASN.Sync
             if (signatureDirty)
             {
                 _signatureStore.Save();
-                await UploadSignatureFileAsync();
+                await UploadSignatureFileAsync().ConfigureAwait(false);
             }
 
             return anyDownloaded;
@@ -432,12 +462,7 @@ namespace YASN.Sync
         /// </summary>
         private string BuildRemotePath(string relativePath)
         {
-            if (string.IsNullOrEmpty(_remoteDirectory))
-            {
-                return relativePath;
-            }
-
-            return $"{_remoteDirectory}/{relativePath}";
+            return string.IsNullOrEmpty(_remoteDirectory) ? relativePath : $"{_remoteDirectory}/{relativePath}";
         }
 
         /// <summary>
@@ -445,12 +470,10 @@ namespace YASN.Sync
         /// </summary>
         private void UpdateLocalSignature(string filePath, string key, ref bool signatureDirty)
         {
-            var hash = FileHashUtil.ComputeFileHash(filePath);
-            if (!string.IsNullOrEmpty(hash))
-            {
-                _signatureStore.Set(key, hash);
-                signatureDirty = true;
-            }
+            string hash = FileHashUtil.ComputeFileHash(filePath);
+            if (string.IsNullOrEmpty(hash)) return;
+            _signatureStore.Set(key, hash);
+            signatureDirty = true;
         }
 
         /// <summary>
@@ -458,30 +481,61 @@ namespace YASN.Sync
         /// </summary>
         private async Task<Dictionary<string, string>> LoadRemoteSignaturesAsync()
         {
-            var signatures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, string> signatures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             if (_client == null)
             {
                 return signatures;
             }
 
-            var remoteSigPath = BuildRemotePath(ManifestFileName);
-            var tempFile = Path.GetTempFileName();
+            string remoteSigPath = BuildRemotePath(ManifestFileName);
+            string tempFile = Path.GetTempFileName();
             try
             {
-                if (await _client.FileExistsAsync(remoteSigPath) &&
-                    await _client.DownloadFileAsync(remoteSigPath, tempFile))
+                if (await _client.FileExistsAsync(remoteSigPath).ConfigureAwait(false) &&
+                    await _client.DownloadFileAsync(remoteSigPath, tempFile).ConfigureAwait(false))
                 {
                     signatures = SignatureStore.LoadFromFile(tempFile);
                 }
             }
-            catch (Exception ex)
+            catch (HttpRequestException ex)
             {
-                AppLogger.Warn($"Failed to load remote signature：{ex.Message}");
+                AppLogger.Warn($"Failed to load remote signature: {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                AppLogger.Warn($"Failed to load remote signature: {ex.Message}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Warn($"Failed to load remote signature: {ex.Message}");
+            }
+            catch (JsonException ex)
+            {
+                AppLogger.Warn($"Failed to load remote signature: {ex.Message}");
+            }
+            catch (TaskCanceledException ex)
+            {
+                AppLogger.Warn($"Failed to load remote signature: {ex.Message}");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                AppLogger.Warn($"Failed to load remote signature: {ex.Message}");
             }
             finally
             {
-                try { File.Delete(tempFile); } catch { }
+                try
+                {
+                    File.Delete(tempFile);
+                }
+                catch (IOException ex)
+                {
+                    AppLogger.Debug($"Failed to delete temp signature file '{tempFile}': {ex.Message}");
+                }
+                catch (UnauthorizedAccessException ex)
+                {
+                    AppLogger.Debug($"Failed to delete temp signature file '{tempFile}': {ex.Message}");
+                }
             }
 
             return signatures;
@@ -497,8 +551,8 @@ namespace YASN.Sync
                 return;
             }
 
-            var remoteSigPath = BuildRemotePath(ManifestFileName);
-            await _client.UploadFileAsync(AppPaths.SignatureFilePath, remoteSigPath);
+            string remoteSigPath = BuildRemotePath(ManifestFileName);
+            await _client.UploadFileAsync(AppPaths.SignatureFilePath, remoteSigPath).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -508,9 +562,9 @@ namespace YASN.Sync
         {
             return await Application.Current.Dispatcher.InvokeAsync(() =>
             {
-                var message =
+                string message =
                     $"远端的 {fileName} 已更新，但内容与本地不同。\n本地修改时间: {localTime:G}\n远端修改时间: {remoteTime:G}\n选择“是”下载远端覆盖本地，选择“否”保留本地并覆盖远端。";
-                var result = MessageBox.Show(message, "同步冲突", System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxImage.Warning);
+                MessageBoxResult result = MessageBox.Show(message, "同步冲突", System.Windows.MessageBoxButton.YesNo, System.Windows.MessageBoxImage.Warning);
                 return result == System.Windows.MessageBoxResult.Yes
                     ? ConflictResolutionAction.DownloadRemote
                     : ConflictResolutionAction.KeepLocal;
@@ -545,7 +599,7 @@ namespace YASN.Sync
         /// </summary>
         private Dictionary<string, string> BuildLocalSyncEntries()
         {
-            var entries = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, string> entries = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             AddIfExists(entries, AppPaths.NotesIndexPath);
             AddDirectoryFiles(entries, AppPaths.NotesMarkdownRoot);
@@ -565,7 +619,7 @@ namespace YASN.Sync
                 return;
             }
 
-            var key = ToSyncKey(fullPath);
+            string key = ToSyncKey(fullPath);
             map[key] = fullPath;
         }
 
@@ -579,9 +633,9 @@ namespace YASN.Sync
                 return;
             }
 
-            foreach (var file in Directory.GetFiles(root, "*", SearchOption.AllDirectories))
+            foreach (string file in Directory.GetFiles(root, "*", SearchOption.AllDirectories))
             {
-                var key = ToSyncKey(file);
+                string key = ToSyncKey(file);
                 map[key] = file;
             }
         }
@@ -591,7 +645,7 @@ namespace YASN.Sync
         /// </summary>
         private static string ToSyncKey(string fullPath)
         {
-            var relative = Path.GetRelativePath(AppPaths.DataDirectory, fullPath);
+            string relative = Path.GetRelativePath(AppPaths.DataDirectory, fullPath);
             return relative.Replace('\\', '/');
         }
 
@@ -600,7 +654,7 @@ namespace YASN.Sync
         /// </summary>
         private static string ToLocalPath(string key)
         {
-            var localRelative = key.Replace('/', Path.DirectorySeparatorChar);
+            string localRelative = key.Replace('/', Path.DirectorySeparatorChar);
             return Path.Combine(AppPaths.DataDirectory, localRelative);
         }
 
@@ -614,17 +668,15 @@ namespace YASN.Sync
                 return false;
             }
 
-            var idx = key.LastIndexOf('/');
-            if (idx > 0)
+            int idx = key.LastIndexOf('/');
+            if (idx <= 0) return await _client.UploadFileAsync(localPath, BuildRemotePath(key)).ConfigureAwait(false);
+            string remoteDir = key.Substring(0, idx);
+            if (!await _client.EnsureDirectoryAsync(BuildRemotePath(remoteDir)).ConfigureAwait(false))
             {
-                var remoteDir = key.Substring(0, idx);
-                if (!await _client.EnsureDirectoryAsync(BuildRemotePath(remoteDir)))
-                {
-                    return false;
-                }
+                return false;
             }
 
-            return await _client.UploadFileAsync(localPath, BuildRemotePath(key));
+            return await _client.UploadFileAsync(localPath, BuildRemotePath(key)).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -637,13 +689,13 @@ namespace YASN.Sync
                 return false;
             }
 
-            var directory = Path.GetDirectoryName(localPath);
+            string? directory = Path.GetDirectoryName(localPath);
             if (!string.IsNullOrEmpty(directory))
             {
                 Directory.CreateDirectory(directory);
             }
 
-            return await _client.DownloadFileAsync(remotePath, localPath);
+            return await _client.DownloadFileAsync(remotePath, localPath).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Sync/WebDav/WebDavSyncClient.cs
+++ b/Sync/WebDav/WebDavSyncClient.cs
@@ -1,9 +1,6 @@
-﻿using System;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Threading.Tasks;
 using WebDav;
 using YASN.Logging;
 
@@ -15,61 +12,41 @@ namespace YASN.Sync.WebDav
     public class WebDavSyncClient : ISyncClient
     {
         private readonly IWebDavClient _client;
+        private readonly HttpClientHandler _httpClientHandler;
+        private readonly HttpClient _httpClient;
 
         public string BackendName => "WebDAV";
-        public string LastError { get; private set; }
+        public string? LastError { get; private set; }
 
         public WebDavSyncClient(WebDavOptions options)
         {
             if (string.IsNullOrWhiteSpace(options.ServerUrl))
                 throw new ArgumentException("ServerUrl is required", nameof(options));
 
-            var handler = new HttpClientHandler
-            {
-                PreAuthenticate = true,
-                UseDefaultCredentials = false,
-                UseProxy = false
-            };
-
-            if (options.AllowInvalidCertificates)
-            {
-                handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-            }
-
-            if (!string.IsNullOrEmpty(options.Username))
-            {
-                handler.Credentials = new NetworkCredential(options.Username, options.Password);
-            }
-
-            var httpClient = new HttpClient(handler)
+            _httpClientHandler = CreateHttpClientHandler(options);
+            _httpClient = new HttpClient(_httpClientHandler, disposeHandler: false)
             {
                 BaseAddress = BuildBaseAddress(options.ServerUrl),
                 Timeout = TimeSpan.FromSeconds(30)
             };
 
-            httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("YASN-WebDav/1.0");
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("YASN-WebDav/1.0");
 
-            _client = new WebDavClient(httpClient);
+            _client = new WebDavClient(_httpClient);
         }
 
         public async Task<bool> TestConnectionAsync(string remotePath)
         {
-            var path = NormalizeRemotePath(remotePath);
+            string path = NormalizeRemotePath(remotePath);
 
             try
             {
-                var response = await _client.Propfind(path, new PropfindParameters
+                PropfindResponse response = await _client.Propfind(path, new PropfindParameters
                 {
                     ApplyTo = ApplyTo.Propfind.ResourceOnly
-                });
+                }).ConfigureAwait(false);
 
-                if (response.IsSuccessful)
-                {
-                    LastError = null;
-                    return true;
-                }
-
-                if (!string.IsNullOrEmpty(path) && await EnsureDirectoryAsync(path))
+                if (response.IsSuccessful || !string.IsNullOrEmpty(path) && await EnsureDirectoryAsync(path).ConfigureAwait(false))
                 {
                     LastError = null;
                     return true;
@@ -78,30 +55,42 @@ namespace YASN.Sync.WebDav
                 LastError = response.Description ?? $"WebDAV status {response.StatusCode}";
                 return false;
             }
-            catch (Exception ex)
+            catch (HttpRequestException ex)
             {
                 LastError = ex.Message;
-                AppLogger.Warn($"WebDAV test failed: {ex}");
+                AppLogger.Warn($"WebDAV test failed: {ex.Message}");
+                return false;
+            }
+            catch (InvalidOperationException ex)
+            {
+                LastError = ex.Message;
+                AppLogger.Warn($"WebDAV test failed: {ex.Message}");
+                return false;
+            }
+            catch (TaskCanceledException ex)
+            {
+                LastError = ex.Message;
+                AppLogger.Warn($"WebDAV test failed: {ex.Message}");
                 return false;
             }
         }
 
         public async Task<bool> EnsureDirectoryAsync(string remotePath)
         {
-            var normalized = NormalizeRemotePath(remotePath);
+            string normalized = NormalizeRemotePath(remotePath);
 
             if (string.IsNullOrEmpty(normalized))
             {
                 return true;
             }
 
-            var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
-            var current = string.Empty;
+            string[] segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            string current = string.Empty;
 
-            foreach (var segment in segments)
+            foreach (string segment in segments)
             {
                 current = string.IsNullOrEmpty(current) ? segment : $"{current}/{segment}";
-                var response = await _client.Mkcol(current);
+                WebDavResponse response = await _client.Mkcol(current).ConfigureAwait(false);
 
                 if (response.IsSuccessful || response.StatusCode == (int)HttpStatusCode.MethodNotAllowed)
                 {
@@ -124,7 +113,7 @@ namespace YASN.Sync.WebDav
 
         public async Task<bool> UploadFileAsync(string localFilePath, string remoteFilePath)
         {
-            var path = NormalizeRemotePath(remoteFilePath);
+            string path = NormalizeRemotePath(remoteFilePath);
 
             if (!File.Exists(localFilePath))
             {
@@ -134,74 +123,139 @@ namespace YASN.Sync.WebDav
 
             try
             {
-                await using var stream = File.OpenRead(localFilePath);
-                var response = await _client.PutFile(path, stream, "application/octet-stream");
-
-                if (response.IsSuccessful)
+                FileStream stream = File.OpenRead(localFilePath);
+                await using (stream.ConfigureAwait(false))
                 {
-                    LastError = null;
-                    return true;
-                }
+                    WebDavResponse response = await _client.PutFile(path, stream, "application/octet-stream").ConfigureAwait(false);
 
-                LastError = response.Description ?? $"Upload failed with status {response.StatusCode}";
-                return false;
+                    if (response.IsSuccessful)
+                    {
+                        LastError = null;
+                        return true;
+                    }
+
+                    LastError = response.Description ?? $"Upload failed with status {response.StatusCode}";
+                    return false;
+                }
             }
-            catch (Exception ex)
+            catch (HttpRequestException ex)
             {
                 LastError = ex.Message;
-                AppLogger.Debug($"WebDAV upload failed: {ex}");
+                AppLogger.Debug($"WebDAV upload failed: {ex.Message}");
+                return false;
+            }
+            catch (IOException ex)
+            {
+                LastError = ex.Message;
+                AppLogger.Debug($"WebDAV upload failed: {ex.Message}");
+                return false;
+            }
+            catch (InvalidOperationException ex)
+            {
+                LastError = ex.Message;
+                AppLogger.Debug($"WebDAV upload failed: {ex.Message}");
+                return false;
+            }
+            catch (TaskCanceledException ex)
+            {
+                LastError = ex.Message;
+                AppLogger.Debug($"WebDAV upload failed: {ex.Message}");
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                LastError = ex.Message;
+                AppLogger.Debug($"WebDAV upload failed: {ex.Message}");
                 return false;
             }
         }
 
         public async Task<bool> DownloadFileAsync(string remoteFilePath, string localFilePath)
         {
-            var path = NormalizeRemotePath(remoteFilePath);
+            string path = NormalizeRemotePath(remoteFilePath);
 
             try
             {
-                var response = await _client.GetRawFile(path);
+                WebDavStreamResponse response = await _client.GetRawFile(path).ConfigureAwait(false);
                 if (!response.IsSuccessful || response.Stream == null)
                 {
                     LastError = response.Description ?? $"Download failed with status {response.StatusCode}";
                     return false;
                 }
 
-                var directory = Path.GetDirectoryName(localFilePath);
+                string? directory = Path.GetDirectoryName(localFilePath);
                 if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }
 
-                await using var responseStream = response.Stream;
-                await using var fileStream = File.Create(localFilePath);
-                await responseStream.CopyToAsync(fileStream);
+                Stream responseStream = response.Stream;
+                FileStream fileStream = File.Create(localFilePath);
+                await using (responseStream.ConfigureAwait(false))
+                await using (fileStream.ConfigureAwait(false))
+                {
+                    await responseStream.CopyToAsync(fileStream).ConfigureAwait(false);
+                }
 
                 LastError = null;
                 return true;
             }
-            catch (Exception ex)
+            catch (HttpRequestException ex)
             {
                 LastError = ex.Message;
-                AppLogger.Debug($"WebDAV download failed: {ex}");
+                AppLogger.Debug($"WebDAV download failed: {ex.Message}");
+                return false;
+            }
+            catch (IOException ex)
+            {
+                LastError = ex.Message;
+                AppLogger.Debug($"WebDAV download failed: {ex.Message}");
+                return false;
+            }
+            catch (InvalidOperationException ex)
+            {
+                LastError = ex.Message;
+                AppLogger.Debug($"WebDAV download failed: {ex.Message}");
+                return false;
+            }
+            catch (TaskCanceledException ex)
+            {
+                LastError = ex.Message;
+                AppLogger.Debug($"WebDAV download failed: {ex.Message}");
+                return false;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                LastError = ex.Message;
+                AppLogger.Debug($"WebDAV download failed: {ex.Message}");
                 return false;
             }
         }
 
         public async Task<bool> FileExistsAsync(string remoteFilePath)
         {
-            var path = NormalizeRemotePath(remoteFilePath);
+            string path = NormalizeRemotePath(remoteFilePath);
 
             try
             {
-                var response = await _client.Propfind(path, new PropfindParameters
+                PropfindResponse response = await _client.Propfind(path, new PropfindParameters
                 {
                     ApplyTo = ApplyTo.Propfind.ResourceOnly
-                });
+                }).ConfigureAwait(false);
 
                 return response.IsSuccessful;
             }
-            catch (Exception ex)
+            catch (HttpRequestException ex)
+            {
+                AppLogger.Debug($"WebDAV exists check failed: {ex.Message}");
+                return false;
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Debug($"WebDAV exists check failed: {ex.Message}");
+                return false;
+            }
+            catch (TaskCanceledException ex)
             {
                 AppLogger.Debug($"WebDAV exists check failed: {ex.Message}");
                 return false;
@@ -210,37 +264,47 @@ namespace YASN.Sync.WebDav
 
         public async Task<DateTime?> GetFileLastModifiedAsync(string remoteFilePath)
         {
-            var path = NormalizeRemotePath(remoteFilePath);
+            string path = NormalizeRemotePath(remoteFilePath);
 
             try
             {
-                var response = await _client.Propfind(path, new PropfindParameters
+                PropfindResponse response = await _client.Propfind(path, new PropfindParameters
                 {
                     ApplyTo = ApplyTo.Propfind.ResourceOnly
-                });
+                }).ConfigureAwait(false);
 
                 if (!response.IsSuccessful)
                 {
                     return null;
                 }
 
-                var resource = response.Resources?.FirstOrDefault();
+                WebDavResource? resource = response.Resources?.FirstOrDefault();
                 return resource?.LastModifiedDate;
             }
-            catch (Exception ex)
+            catch (HttpRequestException ex)
+            {
+                AppLogger.Debug($"WebDAV last-modified check failed: {ex.Message}");
+                return null;
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Debug($"WebDAV last-modified check failed: {ex.Message}");
+                return null;
+            }
+            catch (TaskCanceledException ex)
             {
                 AppLogger.Debug($"WebDAV last-modified check failed: {ex.Message}");
                 return null;
             }
         }
 
-        public async Task<string> GetFileHashAsync(string remoteFilePath)
+        public async Task<string?> GetFileHashAsync(string remoteFilePath)
         {
-            var path = NormalizeRemotePath(remoteFilePath);
+            string path = NormalizeRemotePath(remoteFilePath);
 
             try
             {
-                var response = await _client.GetRawFile(path);
+                WebDavStreamResponse response = await _client.GetRawFile(path).ConfigureAwait(false);
                 if (!response.IsSuccessful || response.Stream == null)
                 {
                     return null;
@@ -251,7 +315,17 @@ namespace YASN.Sync.WebDav
                     return FileHashUtil.ComputeStreamHash(response.Stream);
                 }
             }
-            catch (Exception ex)
+            catch (HttpRequestException ex)
+            {
+                AppLogger.Debug($"WebDAV hash failed: {ex.Message}");
+                return null;
+            }
+            catch (InvalidOperationException ex)
+            {
+                AppLogger.Debug($"WebDAV hash failed: {ex.Message}");
+                return null;
+            }
+            catch (TaskCanceledException ex)
             {
                 AppLogger.Debug($"WebDAV hash failed: {ex.Message}");
                 return null;
@@ -260,16 +334,41 @@ namespace YASN.Sync.WebDav
 
         public void Dispose()
         {
-            _client?.Dispose();
+            _client.Dispose();
+            _httpClient.Dispose();
+            _httpClientHandler.Dispose();
+        }
+
+        private static HttpClientHandler CreateHttpClientHandler(WebDavOptions options)
+        {
+            HttpClientHandler handler = new HttpClientHandler
+            {
+                PreAuthenticate = true,
+                UseDefaultCredentials = false,
+                UseProxy = false,
+                CheckCertificateRevocationList = true
+            };
+
+            if (options.AllowInvalidCertificates)
+            {
+                handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+            }
+
+            if (!string.IsNullOrEmpty(options.Username))
+            {
+                handler.Credentials = new NetworkCredential(options.Username, options.Password);
+            }
+
+            return handler;
         }
 
         private static Uri BuildBaseAddress(string baseAddress)
         {
-            var formatted = baseAddress.TrimEnd('/') + "/";
+            string formatted = baseAddress.TrimEnd('/') + "/";
             return new Uri(formatted);
         }
 
-        private static string NormalizeRemotePath(string remotePath)
+        private static string NormalizeRemotePath(string? remotePath)
         {
             return (remotePath ?? string.Empty).Trim().Trim('/');
         }

--- a/WindowLayout/FloatingWindowQuickActions.cs
+++ b/WindowLayout/FloatingWindowQuickActions.cs
@@ -1,0 +1,178 @@
+using System.Windows;
+using System.Windows.Forms;
+using System.Windows.Interop;
+using YASN.Logging;
+using Point = System.Windows.Point;
+using Screen = System.Windows.Forms.Screen;
+
+namespace YASN.WindowLayout
+{
+    internal static class FloatingWindowQuickActions
+    {
+        private const double FallbackMinWidth = 320;
+        private const double FallbackMinHeight = 220;
+
+        public static void ShowQuickMove(FloatingWindow target)
+        {
+            ShowPicker(target, QuickWindowLayoutMode.Move);
+        }
+
+        public static void ShowQuickMoveAndResize(FloatingWindow target)
+        {
+            ShowPicker(target, QuickWindowLayoutMode.MoveAndResize);
+        }
+
+        public static void ShowQuickResize(FloatingWindow target)
+        {
+            ShowPicker(target, QuickWindowLayoutMode.ResizeOnly);
+        }
+
+        public static void ApplyWindowPosition(FloatingWindow target, double left, double top, VirtualDesktopEntry? desktop = null)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            AppLogger.Debug($"Quick layout apply position for {DescribeTarget(target)} -> left={left:F1}, top={top:F1}, desktop={DescribeDesktop(desktop)}");
+            ApplyWindowBounds(target, new Rect(left, top, target.Width, target.Height), desktop);
+        }
+
+        public static void ApplyWindowSize(FloatingWindow target, double width, double height)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            AppLogger.Debug($"Quick layout apply size for {DescribeTarget(target)} -> width={width:F1}, height={height:F1}");
+            ApplyWindowBounds(target, new Rect(target.Left, target.Top, width, height));
+        }
+
+        public static void ApplyWindowBounds(FloatingWindow target, Rect bounds, VirtualDesktopEntry? desktop = null)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            double minWidth = target.MinWidth > 0 ? target.MinWidth : FallbackMinWidth;
+            double minHeight = target.MinHeight > 0 ? target.MinHeight : FallbackMinHeight;
+
+            Rect normalizedBounds = new Rect(
+                bounds.Left,
+                bounds.Top,
+                Math.Max(minWidth, bounds.Width),
+                Math.Max(minHeight, bounds.Height));
+
+            AppLogger.Debug(
+                $"Quick layout requested bounds for {DescribeTarget(target)}: requested={DescribeRect(bounds)}, normalized={DescribeRect(normalizedBounds)}, min=({minWidth:F1},{minHeight:F1}), desktop={DescribeDesktop(desktop)}");
+
+            if (target.WindowState != WindowState.Normal)
+            {
+                AppLogger.Debug($"Quick layout restoring window state to Normal for {DescribeTarget(target)}");
+                target.WindowState = WindowState.Normal;
+            }
+
+            if (desktop != null)
+            {
+                bool moved = VirtualDesktopCatalog.TryMoveWindowToDesktop(target, desktop);
+                AppLogger.Debug($"Quick layout desktop move result for {DescribeTarget(target)} -> {DescribeDesktop(desktop)} success={moved}");
+            }
+
+            target.Left = normalizedBounds.Left;
+            target.Top = normalizedBounds.Top;
+            target.Width = normalizedBounds.Width;
+            target.Height = normalizedBounds.Height;
+
+            if (target.NoteData != null)
+            {
+                target.NoteData.Left = target.Left;
+                target.NoteData.Top = target.Top;
+                target.NoteData.Width = target.Width;
+                target.NoteData.Height = target.Height;
+                NoteManager.Instance.UpdateNote(target.NoteData);
+            }
+
+            AppLogger.Debug($"Quick layout applied bounds for {DescribeTarget(target)}: actual={DescribeRect(new Rect(target.Left, target.Top, target.Width, target.Height))}");
+            target.ReapplyWindowLevelAfterQuickLayout();
+            target.Activate();
+        }
+
+        public static void RestoreDefaultSize(FloatingWindow target)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            AppLogger.Debug($"Quick layout restore default size for {DescribeTarget(target)} -> {NoteManager.DefaultNoteWidth:F1}x{NoteManager.DefaultNoteHeight:F1}");
+            ApplyWindowBounds(target, new Rect(target.Left, target.Top, NoteManager.DefaultNoteWidth, NoteManager.DefaultNoteHeight));
+        }
+
+        public static void MoveToMouseMonitor(FloatingWindow target)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            Screen screen = Screen.FromPoint(Control.MousePosition);
+            Rect workingArea = new(
+                screen.WorkingArea.Left,
+                screen.WorkingArea.Top,
+                screen.WorkingArea.Width,
+                screen.WorkingArea.Height);
+
+            double width = Math.Min(target.Width, workingArea.Width);
+            double height = Math.Min(target.Height, workingArea.Height);
+            double left = workingArea.Left + Math.Max(0, (workingArea.Width - width) / 2);
+            double top = workingArea.Top + Math.Max(0, (workingArea.Height - height) / 2);
+            AppLogger.Debug(
+                $"Quick layout move-to-mouse-monitor for {DescribeTarget(target)} -> screen='{screen.DeviceName}', workingArea={DescribeRect(workingArea)}, newBounds={DescribeRect(new Rect(left, top, width, height))}");
+            ApplyWindowBounds(target, new Rect(left, top, width, height));
+        }
+
+        private static void ShowPicker(FloatingWindow target, QuickWindowLayoutMode mode)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            AppLogger.Debug($"Opening quick layout picker: mode={mode}, target={DescribeTarget(target)}");
+            WindowLayoutPickerWindow picker = new(target, mode)
+            {
+                Owner = target
+            };
+
+            picker.ShowDialog();
+            AppLogger.Debug($"Quick layout picker closed: mode={mode}, target={DescribeTarget(target)}");
+        }
+
+        private static string DescribeTarget(FloatingWindow target)
+        {
+            if (target.NoteData == null)
+            {
+                return $"windowTitle='{target.Title}'";
+            }
+
+            return $"noteId={target.NoteData.Id}, title='{target.NoteData.Title}'";
+        }
+
+        private static string DescribeDesktop(VirtualDesktopEntry? desktop)
+        {
+            if (desktop == null)
+            {
+                return "current";
+            }
+
+            return $"{desktop.Name} ({desktop.Id})";
+        }
+
+        private static string DescribeRect(Rect rect)
+        {
+            return $"[{rect.Left:F1},{rect.Top:F1},{rect.Width:F1},{rect.Height:F1}]";
+        }
+    }
+}

--- a/WindowLayout/QuickWindowLayoutMode.cs
+++ b/WindowLayout/QuickWindowLayoutMode.cs
@@ -1,0 +1,9 @@
+namespace YASN.WindowLayout
+{
+    internal enum QuickWindowLayoutMode
+    {
+        Move,
+        MoveAndResize,
+        ResizeOnly
+    }
+}

--- a/WindowLayout/VirtualDesktopCatalog.cs
+++ b/WindowLayout/VirtualDesktopCatalog.cs
@@ -1,0 +1,136 @@
+using WindowsDesktop;
+using YASN.Logging;
+
+namespace YASN.WindowLayout
+{
+    internal sealed record VirtualDesktopEntry(VirtualDesktop? Desktop, Guid Id, string Name, bool IsCurrent, bool IsWindowDesktop);
+
+    internal static class VirtualDesktopCatalog
+    {
+        private static bool _virtualDesktopUnavailable;
+        private static string? _virtualDesktopUnavailableReason;
+
+        public static IReadOnlyList<VirtualDesktopEntry> GetDesktops(FloatingWindow? window = null)
+        {
+            if (_virtualDesktopUnavailable)
+            {
+                AppLogger.Debug($"Virtual desktop catalog disabled, fallback for {DescribeWindow(window)}: {_virtualDesktopUnavailableReason}");
+                return CreateFallbackDesktopEntries();
+            }
+
+            try
+            {
+                VirtualDesktop? currentDesktop = VirtualDesktop.Current;
+                Guid currentId = currentDesktop?.Id ?? Guid.Empty;
+                VirtualDesktop? windowDesktop = null;
+                Guid windowDesktopId = Guid.Empty;
+                bool? windowIsCurrentDesktop = null;
+
+                if (window != null)
+                {
+                    try
+                    {
+                        IntPtr hwnd = new System.Windows.Interop.WindowInteropHelper(window).Handle;
+                        if (hwnd != IntPtr.Zero)
+                        {
+                            windowDesktop = VirtualDesktop.FromHwnd(hwnd);
+                            windowDesktopId = windowDesktop?.Id ?? Guid.Empty;
+                            windowIsCurrentDesktop = windowDesktopId != Guid.Empty && windowDesktopId == currentId;
+                        }
+
+                        AppLogger.Debug(
+                            $"Virtual desktop window probe for {DescribeWindow(window)}: hwnd=0x{hwnd.ToInt64():X}, windowDesktop={DescribeDesktop(windowDesktop)}, currentDesktop={DescribeDesktop(currentDesktop)}, isCurrent={windowIsCurrentDesktop}");
+                    }
+                    catch (Exception ex)
+                    {
+                        AppLogger.Warn($"Virtual desktop window probe failed for {DescribeWindow(window)}: {ex.Message}");
+                    }
+                }
+
+                VirtualDesktopEntry[] desktops = VirtualDesktop.GetDesktops()
+                    .Select((desktop, index) => new VirtualDesktopEntry(
+                        desktop,
+                        desktop.Id,
+                        string.IsNullOrWhiteSpace(desktop.Name) ? $"Desktop {index + 1}" : desktop.Name,
+                        desktop.Id == currentId,
+                        desktop.Id == windowDesktopId))
+                    .ToArray();
+
+                AppLogger.Debug(
+                    $"Virtual desktop catalog resolved {desktops.Length} desktop(s) for {DescribeWindow(window)}. Current={desktops.FirstOrDefault(static desktop => desktop.IsCurrent)?.Name ?? "none"} ({currentId}), windowDesktop={desktops.FirstOrDefault(static desktop => desktop.IsWindowDesktop)?.Name ?? "none"} ({windowDesktopId}), windowIsCurrent={windowIsCurrentDesktop?.ToString() ?? "n/a"}");
+                return desktops;
+            }
+            catch (Exception ex)
+            {
+                DisableVirtualDesktopIntegration(ex);
+                AppLogger.Warn($"Virtual desktop catalog fallback for {DescribeWindow(window)}: {ex.Message}");
+                return CreateFallbackDesktopEntries();
+            }
+        }
+
+        public static bool TryMoveWindowToDesktop(FloatingWindow target, VirtualDesktopEntry desktop)
+        {
+            if (target == null || desktop.Desktop == null || _virtualDesktopUnavailable)
+            {
+                return false;
+            }
+
+            try
+            {
+                AppLogger.Debug($"Moving {DescribeWindow(target)} to virtual desktop {desktop.Name} ({desktop.Id})");
+                target.MoveToDesktop(desktop.Desktop);
+                AppLogger.Debug($"Moved {DescribeWindow(target)} to virtual desktop {desktop.Name} ({desktop.Id})");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                DisableVirtualDesktopIntegration(ex);
+                AppLogger.Warn($"Failed to move {DescribeWindow(target)} to virtual desktop {desktop.Name} ({desktop.Id}): {ex.Message}");
+                return false;
+            }
+        }
+
+        public static VirtualDesktopEntry GetCurrentDesktop(FloatingWindow? window = null)
+        {
+            IReadOnlyList<VirtualDesktopEntry> desktops = GetDesktops(window);
+            return desktops.FirstOrDefault(static desktop => desktop.IsCurrent)
+                   ?? desktops.First();
+        }
+
+        private static string DescribeWindow(FloatingWindow? window)
+        {
+            if (window?.NoteData == null)
+            {
+                return "window";
+            }
+
+            return $"noteId={window.NoteData.Id}, title='{window.NoteData.Title}'";
+        }
+
+        private static string DescribeDesktop(VirtualDesktop? desktop)
+        {
+            if (desktop == null)
+            {
+                return "none";
+            }
+
+            string name = string.IsNullOrWhiteSpace(desktop.Name) ? desktop.Id.ToString() : desktop.Name;
+            return $"{name} ({desktop.Id})";
+        }
+
+        private static void DisableVirtualDesktopIntegration(Exception ex)
+        {
+            _virtualDesktopUnavailable = true;
+            _virtualDesktopUnavailableReason = ex.Message;
+            AppLogger.Warn($"Virtual desktop integration disabled after failure: {ex.Message}");
+        }
+
+        private static IReadOnlyList<VirtualDesktopEntry> CreateFallbackDesktopEntries()
+        {
+            return
+            [
+                new VirtualDesktopEntry(null, Guid.Empty, "Current Desktop", true, true)
+            ];
+        }
+    }
+}

--- a/WindowLayout/WindowLayoutPickerWindow.cs
+++ b/WindowLayout/WindowLayoutPickerWindow.cs
@@ -1,0 +1,656 @@
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Bitmap = System.Drawing.Bitmap;
+using CopyPixelOperation = System.Drawing.CopyPixelOperation;
+using DrawingGraphics = System.Drawing.Graphics;
+using DrawingPoint = System.Drawing.Point;
+using DrawingSize = System.Drawing.Size;
+using ImageControl = System.Windows.Controls.Image;
+using YASN.Logging;
+using Color = System.Windows.Media.Color;
+using ImageSource = System.Windows.Media.ImageSource;
+using Point = System.Windows.Point;
+using Rectangle = System.Windows.Shapes.Rectangle;
+using Screen = System.Windows.Forms.Screen;
+
+namespace YASN.WindowLayout
+{
+    internal sealed class WindowLayoutPickerWindow : Window
+    {
+        private const double CompactMaxWidth = 1120;
+        private const double CompactMaxHeight = 760;
+        private const double ResizeOnlyMaxWidth = 1260;
+        private const double ResizeOnlyMaxHeight = 900;
+        private const double SingleDesktopMaxWidth = 1180;
+        private const double SingleDesktopMaxHeight = 720;
+        private const double GalleryDesktopMaxWidth = 320;
+        private const double GalleryDesktopMaxHeight = 210;
+        private const double MinimumSelectionSize = 10;
+
+        private readonly FloatingWindow _target;
+        private readonly QuickWindowLayoutMode _mode;
+        private readonly IReadOnlyList<VirtualDesktopEntry> _desktops;
+        private readonly Rect _desktopBoundsPx;
+        private readonly Rect _targetBoundsPx;
+        private readonly ImageSource? _currentDesktopScreenshot;
+        //private readonly TextBlock _desktopSummaryText = new();
+
+        internal WindowLayoutPickerWindow(FloatingWindow target, QuickWindowLayoutMode mode)
+        {
+            _target = target;
+            _mode = mode;
+            _desktopBoundsPx = GetDesktopBoundsPx();
+            _targetBoundsPx = GetWindowBoundsPx(target);
+            _currentDesktopScreenshot = CaptureCurrentDesktopScreenshot(_desktopBoundsPx);
+
+            IReadOnlyList<VirtualDesktopEntry> desktops = VirtualDesktopCatalog.GetDesktops(target);
+            _desktops = mode == QuickWindowLayoutMode.ResizeOnly
+                ? [VirtualDesktopCatalog.GetCurrentDesktop(target)]
+                : desktops;
+
+            AppLogger.Debug(
+                $"Quick layout picker init: mode={mode}, target={DescribeTarget()}, desktopBoundsPx={DescribeRect(_desktopBoundsPx)}, targetBoundsPx={DescribeRect(_targetBoundsPx)}, desktops={string.Join(", ", _desktops.Select(static desktop => $"{desktop.Name}:{desktop.Id}"))}");
+
+            Title = "Quick Layout";
+            WindowStyle = WindowStyle.None;
+            ResizeMode = ResizeMode.NoResize;
+            AllowsTransparency = true;
+            Background = new SolidColorBrush(Color.FromArgb(0x88, 0x00, 0x00, 0x00));
+            ShowInTaskbar = false;
+            Topmost = true;
+            WindowStartupLocation = WindowStartupLocation.Manual;
+            Left = _desktopBoundsPx.Left;
+            Top = _desktopBoundsPx.Top;
+            Width = Math.Max(1, _desktopBoundsPx.Width);
+            Height = Math.Max(1, _desktopBoundsPx.Height);
+            PreviewKeyDown += WindowLayoutPickerWindow_PreviewKeyDown;
+
+            Content = BuildContent();
+            // UpdateDesktopSummary();
+        }
+
+        private UIElement BuildContent()
+        {
+            Grid root = new()
+            {
+                Background = System.Windows.Media.Brushes.Transparent
+            };
+            root.MouseLeftButtonDown += Root_MouseLeftButtonDown;
+
+            Border panel = new()
+            {
+                HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Background = new SolidColorBrush(Color.FromRgb(0x15, 0x18, 0x1D)),
+                BorderBrush = new SolidColorBrush(Color.FromArgb(0x55, 0xFF, 0xFF, 0xFF)),
+                BorderThickness = new Thickness(1),
+                CornerRadius = new CornerRadius(10),
+                Padding = new Thickness(16),
+                MaxWidth = _mode == QuickWindowLayoutMode.ResizeOnly ? ResizeOnlyMaxWidth : CompactMaxWidth,
+                MaxHeight = _mode == QuickWindowLayoutMode.ResizeOnly ? ResizeOnlyMaxHeight : CompactMaxHeight
+            };
+
+            StackPanel layout = new();
+            layout.Children.Add(new TextBlock
+            {
+                Text = GetTitleText(),
+                Foreground = System.Windows.Media.Brushes.White,
+                FontSize = 21,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 0, 0, 4)
+            });
+            // layout.Children.Add(new TextBlock
+            // {
+            //     Text = GetSubtitleText(),
+            //     Foreground = new SolidColorBrush(Color.FromRgb(0xD6, 0xDB, 0xE2)),
+            //     FontSize = 13,
+            //     Margin = new Thickness(0, 0, 0, 10)
+            // });
+
+            // _desktopSummaryText.Foreground = new SolidColorBrush(Color.FromRgb(0x90, 0xC7, 0xFF));
+            // _desktopSummaryText.FontSize = 12;
+            // _desktopSummaryText.Margin = new Thickness(0, 0, 0, 10);
+            // layout.Children.Add(_desktopSummaryText);
+
+            layout.Children.Add(CreateDesktopGallery());
+            panel.Child = layout;
+            root.Children.Add(panel);
+            return root;
+        }
+
+        private UIElement CreateDesktopGallery()
+        {
+            if (_desktops.Count == 1)
+            {
+                DesktopMapMetrics metrics = DesktopMapMetrics.Create(_desktopBoundsPx, SingleDesktopMaxWidth, SingleDesktopMaxHeight);
+                return CreateDesktopCard(_desktops[0], metrics, false);
+            }
+
+            WrapPanel gallery = new()
+            {
+                Orientation = System.Windows.Controls.Orientation.Horizontal,
+                HorizontalAlignment = System.Windows.HorizontalAlignment.Center
+            };
+
+            DesktopMapMetrics sharedMetrics = DesktopMapMetrics.Create(_desktopBoundsPx, GalleryDesktopMaxWidth, GalleryDesktopMaxHeight);
+            foreach (VirtualDesktopEntry desktop in _desktops)
+            {
+                gallery.Children.Add(CreateDesktopCard(desktop, sharedMetrics, true));
+            }
+
+            AppLogger.Debug($"Quick layout picker gallery created: target={DescribeTarget()}, desktopCount={_desktops.Count}");
+
+            return new ScrollViewer
+            {
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                MaxHeight = CompactMaxHeight - 180,
+                Content = gallery
+            };
+        }
+
+        private UIElement CreateDesktopCard(VirtualDesktopEntry desktop, DesktopMapMetrics metrics, bool compact)
+        {
+            StackPanel cardContent = new();
+            cardContent.Children.Add(new TextBlock
+            {
+                Text = desktop.Name,
+                Foreground = System.Windows.Media.Brushes.White,
+                FontSize = compact ? 13 : 14,
+                FontWeight = FontWeights.SemiBold,
+                Margin = new Thickness(0, 0, 0, 2)
+            });
+            cardContent.Children.Add(new TextBlock
+            {
+                Text = GetDesktopBadgeText(desktop),
+                Foreground = new SolidColorBrush(Color.FromRgb(0xB3, 0xC7, 0xD8)),
+                FontSize = 11,
+                Margin = new Thickness(0, 0, 0, 8)
+            });
+            cardContent.Children.Add(CreateDesktopSurface(desktop, metrics));
+
+            return new Border
+            {
+                Width = metrics.Width + 20,
+                Margin = new Thickness(0, 0, 12, 12),
+                Padding = new Thickness(10),
+                Background = new SolidColorBrush(Color.FromArgb(0x30, 0xFF, 0xFF, 0xFF)),
+                BorderBrush = new SolidColorBrush(desktop.IsCurrent ? Color.FromArgb(0x99, 0x4F, 0xC3, 0xF7) : Color.FromArgb(0x30, 0xFF, 0xFF, 0xFF)),
+                BorderThickness = new Thickness(desktop.IsCurrent ? 2 : 1),
+                CornerRadius = new CornerRadius(8),
+                Child = cardContent
+            };
+        }
+
+        private UIElement CreateDesktopSurface(VirtualDesktopEntry desktop, DesktopMapMetrics metrics)
+        {
+            Grid surface = new()
+            {
+                Width = metrics.Width,
+                Height = metrics.Height,
+                Background = new SolidColorBrush(Color.FromRgb(0x0E, 0x11, 0x16)),
+                ClipToBounds = true
+            };
+
+            surface.Children.Add(CreateDesktopBackground(desktop, metrics));
+            surface.Children.Add(CreateWindowPreviewOverlay(metrics));
+
+            Canvas overlay = new()
+            {
+                Width = metrics.Width,
+                Height = metrics.Height,
+                Background = System.Windows.Media.Brushes.Transparent,
+                Cursor = _mode == QuickWindowLayoutMode.Move ? System.Windows.Input.Cursors.Hand : System.Windows.Input.Cursors.Cross
+            };
+
+            if (_mode == QuickWindowLayoutMode.Move)
+            {
+                overlay.MouseLeftButtonUp += (_, e) =>
+                {
+                    Point clickedPoint = e.GetPosition(overlay);
+                    Point screenPointPx = metrics.CanvasToScreen(clickedPoint);
+                    Rect newBoundsPx = new(screenPointPx.X, screenPointPx.Y, _targetBoundsPx.Width, _targetBoundsPx.Height);
+                    AppLogger.Debug(
+                        $"Quick layout picker click move: target={DescribeTarget()}, desktop={desktop.Name} ({desktop.Id}), canvasPoint={DescribePoint(clickedPoint)}, screenPointPx={DescribePoint(screenPointPx)}, boundsPx={DescribeRect(newBoundsPx)}");
+                    Close();
+                    FloatingWindowQuickActions.ApplyWindowBounds(_target, PixelsToDipRect(newBoundsPx), desktop);
+                };
+            }
+            else
+            {
+                AddSelectionBehavior(overlay, metrics, desktop);
+            }
+
+            surface.Children.Add(overlay);
+
+            return new Border
+            {
+                CornerRadius = new CornerRadius(8),
+                BorderBrush = new SolidColorBrush(Color.FromArgb(0x44, 0xFF, 0xFF, 0xFF)),
+                BorderThickness = new Thickness(1),
+                Child = surface
+            };
+        }
+
+        private UIElement CreateDesktopBackground(VirtualDesktopEntry desktop, DesktopMapMetrics metrics)
+        {
+            if (desktop.IsCurrent && _currentDesktopScreenshot != null)
+            {
+                AppLogger.Debug($"Quick layout picker background: using current desktop screenshot for {DescribeTarget()} on {desktop.Name} ({desktop.Id})");
+                return new ImageControl
+                {
+                    Source = _currentDesktopScreenshot,
+                    Width = metrics.Width,
+                    Height = metrics.Height,
+                    Stretch = Stretch.Fill,
+                    IsHitTestVisible = false
+                };
+            }
+
+            string fallbackReason = desktop.IsCurrent ? "screenshot capture failed" : "selected desktop is not current";
+            AppLogger.Debug($"Quick layout picker background: using placeholder for {DescribeTarget()} on {desktop.Name} ({desktop.Id}) because {fallbackReason}");
+            return CreateDesktopPlaceholder(metrics, desktop);
+        }
+
+        private UIElement CreateDesktopPlaceholder(DesktopMapMetrics metrics, VirtualDesktopEntry desktop)
+        {
+            Grid placeholder = new()
+            {
+                Width = metrics.Width,
+                Height = metrics.Height,
+                Background = new LinearGradientBrush(
+                    Color.FromRgb(0x16, 0x1B, 0x22),
+                    Color.FromRgb(0x0F, 0x13, 0x18),
+                    90)
+            };
+
+            Canvas monitorCanvas = new()
+            {
+                Width = metrics.Width,
+                Height = metrics.Height,
+                IsHitTestVisible = false
+            };
+
+            int screenIndex = 1;
+            foreach (Screen screen in Screen.AllScreens)
+            {
+                Rect monitorBounds = new(screen.Bounds.X, screen.Bounds.Y, screen.Bounds.Width, screen.Bounds.Height);
+                Rect scaledMonitor = metrics.ScreenToCanvas(monitorBounds);
+
+                Border monitorRect = new()
+                {
+                    Width = Math.Max(12, scaledMonitor.Width),
+                    Height = Math.Max(12, scaledMonitor.Height),
+                    Background = new SolidColorBrush(Color.FromArgb(0x24, 0xFF, 0xFF, 0xFF)),
+                    BorderBrush = new SolidColorBrush(Color.FromArgb(0x66, 0xFF, 0xFF, 0xFF)),
+                    BorderThickness = new Thickness(1),
+                    CornerRadius = new CornerRadius(4)
+                };
+                monitorCanvas.Children.Add(monitorRect);
+                Canvas.SetLeft(monitorRect, scaledMonitor.Left);
+                Canvas.SetTop(monitorRect, scaledMonitor.Top);
+
+                TextBlock monitorLabel = new()
+                {
+                    Text = $"Display {screenIndex}",
+                    Foreground = new SolidColorBrush(Color.FromRgb(0xE6, 0xEB, 0xF0)),
+                    FontSize = 11,
+                    FontWeight = FontWeights.SemiBold
+                };
+                monitorCanvas.Children.Add(monitorLabel);
+                Canvas.SetLeft(monitorLabel, scaledMonitor.Left + 8);
+                Canvas.SetTop(monitorLabel, scaledMonitor.Top + 6);
+
+                screenIndex++;
+            }
+
+            TextBlock placeholderLabel = new()
+            {
+                Text = desktop.IsCurrent ? "Current desktop placeholder" : "Virtual desktop placeholder",
+                Foreground = new SolidColorBrush(Color.FromArgb(0xCC, 0xFF, 0xFF, 0xFF)),
+                FontSize = 15,
+                FontWeight = FontWeights.SemiBold,
+                HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+
+            TextBlock resolutionLabel = new()
+            {
+                Text = $"{Math.Round(_desktopBoundsPx.Width)} x {Math.Round(_desktopBoundsPx.Height)}",
+                Foreground = new SolidColorBrush(Color.FromArgb(0xB3, 0xFF, 0xFF, 0xFF)),
+                FontSize = 12,
+                HorizontalAlignment = System.Windows.HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(0, 28, 0, 0)
+            };
+
+            placeholder.Children.Add(monitorCanvas);
+            placeholder.Children.Add(placeholderLabel);
+            placeholder.Children.Add(resolutionLabel);
+            return placeholder;
+        }
+
+        private UIElement CreateWindowPreviewOverlay(DesktopMapMetrics metrics)
+        {
+            Canvas canvas = new()
+            {
+                Width = metrics.Width,
+                Height = metrics.Height,
+                IsHitTestVisible = false
+            };
+
+            Rect targetRect = metrics.ScreenToCanvas(_targetBoundsPx);
+            Border preview = new()
+            {
+                Width = Math.Max(24, targetRect.Width),
+                Height = Math.Max(18, targetRect.Height),
+                Background = new SolidColorBrush(Color.FromArgb(0x26, 0xFF, 0xC1, 0x07)),
+                BorderBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0xC1, 0x07)),
+                BorderThickness = new Thickness(2),
+                CornerRadius = new CornerRadius(4)
+            };
+
+            TextBlock previewLabel = new()
+            {
+                Text = "Current window",
+                Foreground = System.Windows.Media.Brushes.White,
+                FontSize = 11,
+                FontWeight = FontWeights.SemiBold
+            };
+
+            canvas.Children.Add(preview);
+            canvas.Children.Add(previewLabel);
+            Canvas.SetLeft(preview, targetRect.Left);
+            Canvas.SetTop(preview, targetRect.Top);
+            Canvas.SetLeft(previewLabel, targetRect.Left + 6);
+            Canvas.SetTop(previewLabel, targetRect.Top + 4);
+            return canvas;
+        }
+
+        private void AddSelectionBehavior(Canvas overlay, DesktopMapMetrics metrics, VirtualDesktopEntry desktop)
+        {
+            Point? dragStart = null;
+            Rectangle selectionRect = new()
+            {
+                Stroke = new SolidColorBrush(Color.FromRgb(0x4F, 0xC3, 0xF7)),
+                StrokeThickness = 2,
+                Fill = new SolidColorBrush(Color.FromArgb(0x30, 0x4F, 0xC3, 0xF7)),
+                Visibility = Visibility.Collapsed,
+                IsHitTestVisible = false
+            };
+
+            overlay.Children.Add(selectionRect);
+
+            overlay.MouseLeftButtonDown += (_, e) =>
+            {
+                dragStart = e.GetPosition(overlay);
+                selectionRect.Visibility = Visibility.Visible;
+                Canvas.SetLeft(selectionRect, dragStart.Value.X);
+                Canvas.SetTop(selectionRect, dragStart.Value.Y);
+                selectionRect.Width = 0;
+                selectionRect.Height = 0;
+                overlay.CaptureMouse();
+                AppLogger.Debug($"Quick layout picker drag start: target={DescribeTarget()}, desktop={desktop.Name} ({desktop.Id}), point={DescribePoint(dragStart.Value)}");
+            };
+
+            overlay.MouseMove += (_, e) =>
+            {
+                if (!dragStart.HasValue || !overlay.IsMouseCaptured)
+                {
+                    return;
+                }
+
+                Rect rect = CreateRect(dragStart.Value, e.GetPosition(overlay));
+                Canvas.SetLeft(selectionRect, rect.Left);
+                Canvas.SetTop(selectionRect, rect.Top);
+                selectionRect.Width = rect.Width;
+                selectionRect.Height = rect.Height;
+            };
+
+            overlay.MouseLeftButtonUp += (_, e) =>
+            {
+                if (!dragStart.HasValue)
+                {
+                    return;
+                }
+
+                Rect selection = CreateRect(dragStart.Value, e.GetPosition(overlay));
+                Point releasePoint = e.GetPosition(overlay);
+                Point startPoint = dragStart.Value;
+                dragStart = null;
+                overlay.ReleaseMouseCapture();
+                selectionRect.Visibility = Visibility.Collapsed;
+
+                if (selection.Width < MinimumSelectionSize || selection.Height < MinimumSelectionSize)
+                {
+                    Point screenPointPx = metrics.CanvasToScreen(releasePoint);
+                    Rect newBoundsPx = new(screenPointPx.X, screenPointPx.Y, _targetBoundsPx.Width, _targetBoundsPx.Height);
+                    AppLogger.Debug(
+                        $"Quick layout picker click-position mode: target={DescribeTarget()}, desktop={desktop.Name} ({desktop.Id}), start={DescribePoint(startPoint)}, release={DescribePoint(releasePoint)}, screenPointPx={DescribePoint(screenPointPx)}, boundsPx={DescribeRect(newBoundsPx)}");
+                    Close();
+                    FloatingWindowQuickActions.ApplyWindowBounds(_target, PixelsToDipRect(newBoundsPx), desktop);
+                    return;
+                }
+
+                Rect resizedBoundsPx = metrics.CanvasToScreen(selection);
+                AppLogger.Debug(
+                    $"Quick layout picker drag apply: target={DescribeTarget()}, desktop={desktop.Name} ({desktop.Id}), selection={DescribeRect(selection)}, boundsPx={DescribeRect(resizedBoundsPx)}");
+                Close();
+                FloatingWindowQuickActions.ApplyWindowBounds(_target, PixelsToDipRect(resizedBoundsPx), desktop);
+            };
+        }
+
+        // private void UpdateDesktopSummary()
+        // {
+        //     int currentCount = _desktops.Count(static desktop => desktop.IsCurrent);
+        //     int windowCount = _desktops.Count(static desktop => desktop.IsWindowDesktop);
+        //     string previewMode = _currentDesktopScreenshot == null ? "placeholder only" : "current desktop screenshot + placeholder fallback";
+        //     _desktopSummaryText.Text = $"Showing {_desktops.Count} virtual desktop thumbnail(s) side by side | current={currentCount} | windowDesktop={windowCount} | {previewMode}";
+        // }
+
+        private string GetTitleText()
+        {
+            return _mode switch
+            {
+                QuickWindowLayoutMode.Move => "Quick Move",
+                QuickWindowLayoutMode.MoveAndResize => "Quick Move + Resize",
+                _ => "Quick Resize"
+            };
+        }
+
+        // private string GetSubtitleText()
+        // {
+        //     return _mode switch
+        //     {
+        //         QuickWindowLayoutMode.Move => "Virtual desktops are shown side by side. Click directly on the target thumbnail to move the window there.",
+        //         QuickWindowLayoutMode.MoveAndResize => "Virtual desktops are shown side by side. Drag a rectangle on the target thumbnail to set position and size; a short click only changes position.",
+        //         _ => "Drag a rectangle to resize and reposition on the current desktop. A short click only changes position."
+        //     };
+        // }
+
+        private Rect PixelsToDipRect(Rect pixelRect)
+        {
+            Matrix fromDevice = GetTransformFromDevice();
+            Point topLeft = fromDevice.Transform(new Point(pixelRect.Left, pixelRect.Top));
+            Point bottomRight = fromDevice.Transform(new Point(pixelRect.Right, pixelRect.Bottom));
+            return new Rect(topLeft, bottomRight);
+        }
+
+        private Matrix GetTransformFromDevice()
+        {
+            PresentationSource? source = PresentationSource.FromVisual(_target);
+            return source?.CompositionTarget?.TransformFromDevice ?? Matrix.Identity;
+        }
+
+        private static Rect CreateRect(Point start, Point end)
+        {
+            return new Rect(
+                Math.Min(start.X, end.X),
+                Math.Min(start.Y, end.Y),
+                Math.Abs(end.X - start.X),
+                Math.Abs(end.Y - start.Y));
+        }
+
+        private static Rect GetDesktopBoundsPx()
+        {
+            Rect[] monitorBounds = Screen.AllScreens
+                .Select(screen => new Rect(screen.Bounds.X, screen.Bounds.Y, screen.Bounds.Width, screen.Bounds.Height))
+                .ToArray();
+
+            double left = monitorBounds.Min(static rect => rect.Left);
+            double top = monitorBounds.Min(static rect => rect.Top);
+            double right = monitorBounds.Max(static rect => rect.Right);
+            double bottom = monitorBounds.Max(static rect => rect.Bottom);
+            return new Rect(left, top, right - left, bottom - top);
+        }
+
+        private static Rect GetWindowBoundsPx(FloatingWindow target)
+        {
+            PresentationSource? source = PresentationSource.FromVisual(target);
+            Matrix toDevice = source?.CompositionTarget?.TransformToDevice ?? Matrix.Identity;
+            Point topLeft = toDevice.Transform(new Point(target.Left, target.Top));
+            Point bottomRight = toDevice.Transform(new Point(target.Left + target.Width, target.Top + target.Height));
+            return new Rect(topLeft, bottomRight);
+        }
+
+        private static ImageSource? CaptureCurrentDesktopScreenshot(Rect desktopBoundsPx)
+        {
+            int width = Math.Max(1, (int)Math.Round(desktopBoundsPx.Width));
+            int height = Math.Max(1, (int)Math.Round(desktopBoundsPx.Height));
+
+            try
+            {
+                using Bitmap bitmap = new(width, height, System.Drawing.Imaging.PixelFormat.Format32bppPArgb);
+                using DrawingGraphics graphics = DrawingGraphics.FromImage(bitmap);
+                graphics.CopyFromScreen(
+                    new DrawingPoint((int)Math.Round(desktopBoundsPx.Left), (int)Math.Round(desktopBoundsPx.Top)),
+                    DrawingPoint.Empty,
+                    new DrawingSize(width, height),
+                    CopyPixelOperation.SourceCopy);
+
+                IntPtr hBitmap = bitmap.GetHbitmap();
+                try
+                {
+                    BitmapSource source = Imaging.CreateBitmapSourceFromHBitmap(
+                        hBitmap,
+                        IntPtr.Zero,
+                        Int32Rect.Empty,
+                        BitmapSizeOptions.FromEmptyOptions());
+                    source.Freeze();
+                    AppLogger.Debug($"Quick layout picker captured current desktop screenshot: boundsPx={DescribeRect(desktopBoundsPx)}");
+                    return source;
+                }
+                finally
+                {
+                    DeleteObject(hBitmap);
+                }
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Warn($"Quick layout picker failed to capture current desktop screenshot: {ex.Message}");
+                return null;
+            }
+        }
+
+        private void Root_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.OriginalSource != sender) return;
+            AppLogger.Debug($"Quick layout picker dismissed by background click: target={DescribeTarget()}, mode={_mode}");
+            Close();
+        }
+
+        private void WindowLayoutPickerWindow_PreviewKeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                AppLogger.Debug($"Quick layout picker dismissed by Escape: target={DescribeTarget()}, mode={_mode}");
+                Close();
+                e.Handled = true;
+            }
+        }
+
+        private string DescribeTarget()
+        {
+            return _target.NoteData == null ? $"windowTitle='{_target.Title}'" : $"noteId={_target.NoteData.Id}, title='{_target.NoteData.Title}'";
+        }
+
+        private static string DescribeRect(Rect rect)
+        {
+            return $"[{rect.Left:F1},{rect.Top:F1},{rect.Width:F1},{rect.Height:F1}]";
+        }
+
+        private static string DescribePoint(Point point)
+        {
+            return $"({point.X:F1},{point.Y:F1})";
+        }
+
+        private static string GetDesktopBadgeText(VirtualDesktopEntry desktop)
+        {
+            List<string> badges = [];
+            if (desktop.IsCurrent)
+            {
+                badges.Add("current");
+            }
+
+            if (desktop.IsWindowDesktop)
+            {
+                badges.Add("window");
+            }
+
+            if (badges.Count == 0)
+            {
+                badges.Add("virtual desktop");
+            }
+
+            return string.Join(" | ", badges);
+        }
+
+        private sealed record DesktopMapMetrics(double Width, double Height, Rect DesktopBoundsPx, double Scale)
+        {
+            public static DesktopMapMetrics Create(Rect desktopBoundsPx, double maxWidth, double maxHeight)
+            {
+                double desktopWidth = Math.Max(1, desktopBoundsPx.Width);
+                double desktopHeight = Math.Max(1, desktopBoundsPx.Height);
+                double scale = Math.Min(maxWidth / desktopWidth, maxHeight / desktopHeight);
+                return new DesktopMapMetrics(desktopWidth * scale, desktopHeight * scale, desktopBoundsPx, scale);
+            }
+
+            public Rect ScreenToCanvas(Rect screenRect)
+            {
+                Point topLeft = ScreenToCanvas(new Point(screenRect.Left, screenRect.Top));
+                Point bottomRight = ScreenToCanvas(new Point(screenRect.Right, screenRect.Bottom));
+                return new Rect(topLeft, bottomRight);
+            }
+
+            public Point CanvasToScreen(Point canvasPoint)
+            {
+                double x = canvasPoint.X / Scale + DesktopBoundsPx.Left;
+                double y = canvasPoint.Y / Scale + DesktopBoundsPx.Top;
+                return new Point(x, y);
+            }
+
+            public Rect CanvasToScreen(Rect canvasRect)
+            {
+                Point topLeft = CanvasToScreen(new Point(canvasRect.Left, canvasRect.Top));
+                Point bottomRight = CanvasToScreen(new Point(canvasRect.Right, canvasRect.Bottom));
+                return new Rect(topLeft, bottomRight);
+            }
+
+            private Point ScreenToCanvas(Point screenPoint)
+            {
+                return new Point(
+                    (screenPoint.X - DesktopBoundsPx.Left) * Scale,
+                    (screenPoint.Y - DesktopBoundsPx.Top) * Scale);
+            }
+        }
+
+        [DllImport("gdi32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DeleteObject(IntPtr hObject);
+    }
+}

--- a/YASN.csproj
+++ b/YASN.csproj
@@ -26,6 +26,8 @@
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="ModernWpf.MessageBox" Version="0.5.2" />
     <PackageReference Include="ModernWpfUI" Version="0.9.6" />
+    <PackageReference Include="Slions.VirtualDesktop" Version="6.9.2" />
+    <PackageReference Include="Slions.VirtualDesktop.WPF" Version="6.9.2" />
     <PackageReference Include="WebDav.Client" Version="2.9.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Resolves #5 through this pr.

Users can quickly resize the note window using the button in the title bar. Further operations, such as moving/resizing between different monitors/virtual desktops, can be triggered via: 
1. the drop-down menu by right-clicking the title bar; 
3. right-clicking the corresponding note item in the main window.

Linter rules are  also included in this pr. 

This pr also try to use right click` at title bat instead `more` button in title bar to rise context menu